### PR TITLE
Vex 0.4.1 — Edit mode, Snippets, and Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to Vex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-21
+
+### Added
+- **Snippet library system**: a curated set of 42 builtin QEMU argument
+  snippets (Memory, CPU, Machine, Storage, Network, Display, Debug,
+  Kernel) plus a `~/.vex/snippets.json` user library for custom entries.
+  User snippets merge with builtins, with user entries overriding by name.
+- **TUI Edit mode**: press `e` on a configuration to edit it in-place,
+  or `n` to create a new one. Fields: name, QEMU binary, description,
+  and args (with reorder, delete, add, and in-place token editing).
+  Resources remain CLI-managed.
+- **TUI Snippets drawer** (Edit mode, right pane): merged snippets
+  grouped by category with fold/unfold, filter, and `→` to insert into
+  the current args position.
+- **TUI Library mode** (`Ctrl+L`): full-screen snippet manager. Browse
+  every snippet with a details panel; press `n` / `e` / `d` to create,
+  edit, or delete user snippets. Persists to `~/.vex/snippets.json`
+  via atomic write (temp-file + rename).
+- **Args token editing**: in Edit mode and Library snippet edit, press
+  `Enter` on an arg to edit its string in place, or `a` to add a new
+  empty arg and immediately start editing it. `Enter` / `Esc` commit.
+
+### Changed
+- **Edit mode `Tab` semantics**: `Tab` switches between the Editor and
+  Snippets panes; field cycling within the Editor uses `↑` / `↓`. (Edit
+  mode is new in 0.4.1, so this is documented for completeness.)
+
+### Notes
+- Snippets file uses `schema_version: 1`. Forward-compatible
+  deserialization is planned for a later release.
+- Builtin snippets are read-only; `e` / `d` on a builtin shows a hint
+  pointing to `n` instead.
+- Carry-over from 0.4.0 development: help overlay is panic-safe on
+  tiny terminals, right-pane scroll clamps and writes back, Ctrl+C
+  always quits regardless of mode/overlay.
+
 ## [0.4.0] - 2026-05-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vex"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vex"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,51 @@ press Enter to launch the selected configuration, and q or Esc to quit.
 Press `/` to filter the list by name or description. Type to refine,
 Enter to accept (keep filter active), or Esc to clear.
 
+### Edit mode
+
+Press `e` on a configuration to edit it, or `n` to create a new one.
+The Edit pane has four fields: name, QEMU binary, description, and args.
+
+- `Tab` switches between the Editor (left) and the Snippets drawer
+  (right).
+- `↑` / `↓` cycle fields in the Editor; in the Args field they navigate
+  rows. `←` / `→` move the cursor inside text fields.
+- In the Args field: `a` adds an empty arg and starts editing it,
+  `Enter` edits the currently-selected arg token, `J` / `K` reorder
+  args, `d` deletes the selected arg.
+- `Ctrl+S` saves and exits. `Esc` cancels (and prompts to confirm if
+  there are unsaved changes).
+
+### Snippets drawer
+
+The right pane of Edit mode shows the merged snippet library (builtin
++ user, ordered by category). Press `Tab` to focus it, then:
+
+- `↑` / `↓` to navigate, `Space` to fold/unfold a category.
+- `/` to filter, `→` to insert the selected snippet into the current
+  args position.
+
+### Library mode
+
+Press `Ctrl+L` from Browse mode to open the full-screen snippet
+manager. Browse all snippets with a details panel on the right; press
+`n` to create a new user snippet, `e` to edit the selected user
+snippet, `d` to delete it. Builtin snippets are read-only; `e` / `d`
+on a builtin shows a hint pointing to `n` instead. Saves persist to
+`~/.vex/snippets.json` via an atomic write.
+
+## Snippets system
+
+A **snippet** is a named, categorised piece of QEMU args. Vex ships
+with 42 builtin snippets across 8 categories (Memory, CPU, Machine,
+Storage, Network, Display, Debug, Kernel) covering the most common
+QEMU recipes. Users add their own via Library mode; the file lives at
+`$VEX_CONFIG_DIR/snippets.json` (default: `~/.vex/snippets.json`).
+
+User snippets merge with builtins by name: a user entry sharing a
+builtin's name overrides it in-place; user-only entries append at the
+end. Builtin entries are never written to the user file.
+
 ### Requirements
 
 - A terminal at least 100 columns wide is recommended.
@@ -71,6 +116,14 @@ Enter to accept (keep filter active), or Esc to clear.
 **Help overlay** — in-TUI keybinding reference:
 
 ![Help overlay](docs/screenshots/help.png)
+
+**Edit mode** — interactive configuration editor with snippets drawer:
+
+![Edit mode](docs/screenshots/edit-mode.png)
+
+**Library mode** — manage your snippet collection:
+
+![Library mode](docs/screenshots/library-mode.png)
 
 **Broken configuration** — visible error state with actionable hints:
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ pub mod validation;
 
 #[cfg(test)]
 pub(crate) use storage::load_config_from_dir;
-pub use storage::{config_dir, config_file, load_config, resource_cache_dir};
+pub use storage::{config_dir, config_file, load_config, resource_cache_dir, vex_root_dir};
 pub use types::{QemuConfig, ResourceKind, ResourceRef};
 pub use validation::{
     parse_config_json, sanitize_config_name, validate_config, validate_config_name,

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -29,6 +29,32 @@ pub fn config_dir() -> VexResult<PathBuf> {
     Ok(dir)
 }
 
+/// `$VEX_CONFIG_DIR` (non-empty) or `~/.vex`. Sibling to `configs/` in
+/// default mode; coincides with `config_dir()` in env mode — a P3 carry-
+/// over of the `VEX_CONFIG_DIR` double meaning, scheduled for 0.4.2.
+pub fn vex_root_dir() -> VexResult<PathBuf> {
+    let dir = match std::env::var("VEX_CONFIG_DIR") {
+        Ok(path) if !path.is_empty() => PathBuf::from(path),
+        _ => {
+            let home = dirs::home_dir().ok_or_else(|| VexError::IoError {
+                path: PathBuf::from("~"),
+                operation: "resolve home directory".to_string(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "failed to get user home directory",
+                ),
+            })?;
+            home.join(".vex")
+        }
+    };
+    fs::create_dir_all(&dir).map_err(|e| VexError::IoError {
+        path: dir.clone(),
+        operation: "create vex root directory".to_string(),
+        source: e,
+    })?;
+    Ok(dir)
+}
+
 pub fn config_file(name: &str) -> VexResult<PathBuf> {
     let dir = config_dir()?;
     Ok(dir.join(format!("{}.json", name)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod config;
 pub mod error;
 pub mod hub;
 pub mod remote;
+pub mod snippets;
 pub mod tui;
 pub mod utils;
 

--- a/src/snippets/builtin.rs
+++ b/src/snippets/builtin.rs
@@ -1,0 +1,292 @@
+use super::types::{Snippet, SnippetCategory};
+
+/// Construct the built-in snippet library (42 entries).
+///
+/// Order is fixed: Memory → CPU → Machine → Storage → Network →
+/// Display → Debug → Kernel, each section in the order documented
+/// in P4-6.
+pub fn builtin_snippets() -> Vec<Snippet> {
+    vec![
+        // --- Memory (5) ---
+        Snippet {
+            name: "512M memory".to_string(),
+            args: vec!["-m".to_string(), "512M".to_string()],
+            category: SnippetCategory::Memory,
+            description: Some("Allocate 512 MB of guest memory".to_string()),
+        },
+        Snippet {
+            name: "1G memory".to_string(),
+            args: vec!["-m".to_string(), "1G".to_string()],
+            category: SnippetCategory::Memory,
+            description: Some("Allocate 1 GB of guest memory".to_string()),
+        },
+        Snippet {
+            name: "2G memory".to_string(),
+            args: vec!["-m".to_string(), "2G".to_string()],
+            category: SnippetCategory::Memory,
+            description: Some("Allocate 2 GB of guest memory".to_string()),
+        },
+        Snippet {
+            name: "4G memory".to_string(),
+            args: vec!["-m".to_string(), "4G".to_string()],
+            category: SnippetCategory::Memory,
+            description: Some("Allocate 4 GB of guest memory".to_string()),
+        },
+        Snippet {
+            name: "8G memory".to_string(),
+            args: vec!["-m".to_string(), "8G".to_string()],
+            category: SnippetCategory::Memory,
+            description: Some("Allocate 8 GB of guest memory".to_string()),
+        },
+        // --- CPU (6) ---
+        Snippet {
+            name: "1 CPU".to_string(),
+            args: vec!["-smp".to_string(), "1".to_string()],
+            category: SnippetCategory::Cpu,
+            description: Some("Single CPU core".to_string()),
+        },
+        Snippet {
+            name: "2 CPUs".to_string(),
+            args: vec!["-smp".to_string(), "2".to_string()],
+            category: SnippetCategory::Cpu,
+            description: Some("2 CPU cores".to_string()),
+        },
+        Snippet {
+            name: "4 CPUs".to_string(),
+            args: vec!["-smp".to_string(), "4".to_string()],
+            category: SnippetCategory::Cpu,
+            description: Some("4 CPU cores".to_string()),
+        },
+        Snippet {
+            name: "8 CPUs".to_string(),
+            args: vec!["-smp".to_string(), "8".to_string()],
+            category: SnippetCategory::Cpu,
+            description: Some("8 CPU cores".to_string()),
+        },
+        Snippet {
+            name: "Host CPU".to_string(),
+            args: vec!["-cpu".to_string(), "host".to_string()],
+            category: SnippetCategory::Cpu,
+            description: Some("Expose host CPU features (KVM only)".to_string()),
+        },
+        Snippet {
+            name: "Cortex-A72".to_string(),
+            args: vec!["-cpu".to_string(), "cortex-a72".to_string()],
+            category: SnippetCategory::Cpu,
+            description: Some("ARM Cortex-A72 (Raspberry Pi 4)".to_string()),
+        },
+        // --- Machine (4) ---
+        Snippet {
+            name: "virt machine".to_string(),
+            args: vec!["-M".to_string(), "virt".to_string()],
+            category: SnippetCategory::Machine,
+            description: Some("Generic ARM virtual machine".to_string()),
+        },
+        Snippet {
+            name: "q35 machine".to_string(),
+            args: vec!["-M".to_string(), "q35".to_string()],
+            category: SnippetCategory::Machine,
+            description: Some("Modern x86_64 machine (PCIe, AHCI)".to_string()),
+        },
+        Snippet {
+            name: "raspi3b machine".to_string(),
+            args: vec!["-M".to_string(), "raspi3b".to_string()],
+            category: SnippetCategory::Machine,
+            description: Some("Raspberry Pi 3B emulation".to_string()),
+        },
+        Snippet {
+            name: "microvm machine".to_string(),
+            args: vec!["-M".to_string(), "microvm".to_string()],
+            category: SnippetCategory::Machine,
+            description: Some("Minimal x86_64 for fast boot".to_string()),
+        },
+        // --- Storage (7) ---
+        Snippet {
+            name: "virtio drive".to_string(),
+            args: vec!["-drive".to_string(), "file=disk.img,if=virtio".to_string()],
+            category: SnippetCategory::Storage,
+            description: Some("Attach disk image via virtio (high performance)".to_string()),
+        },
+        Snippet {
+            name: "IDE hard disk".to_string(),
+            args: vec!["-hda".to_string(), "disk.img".to_string()],
+            category: SnippetCategory::Storage,
+            description: Some("Legacy IDE primary disk".to_string()),
+        },
+        Snippet {
+            name: "CDROM ISO".to_string(),
+            args: vec!["-cdrom".to_string(), "image.iso".to_string()],
+            category: SnippetCategory::Storage,
+            description: Some("Attach ISO as CDROM".to_string()),
+        },
+        Snippet {
+            name: "raw image".to_string(),
+            args: vec!["-drive".to_string(), "file=disk.img,format=raw".to_string()],
+            category: SnippetCategory::Storage,
+            description: Some("Raw disk image".to_string()),
+        },
+        Snippet {
+            name: "qcow2 image".to_string(),
+            args: vec![
+                "-drive".to_string(),
+                "file=disk.qcow2,format=qcow2".to_string(),
+            ],
+            category: SnippetCategory::Storage,
+            description: Some("QCOW2 disk image".to_string()),
+        },
+        Snippet {
+            name: "read-only drive".to_string(),
+            args: vec![
+                "-drive".to_string(),
+                "file=disk.img,readonly=on".to_string(),
+            ],
+            category: SnippetCategory::Storage,
+            description: Some("Attach disk in read-only mode".to_string()),
+        },
+        Snippet {
+            name: "MTD flash".to_string(),
+            args: vec!["-drive".to_string(), "file=flash.bin,if=mtd".to_string()],
+            category: SnippetCategory::Storage,
+            description: Some("Attach MTD flash (firmware ROMs)".to_string()),
+        },
+        // --- Network (4) ---
+        Snippet {
+            name: "user mode network".to_string(),
+            args: vec![
+                "-netdev".to_string(),
+                "user,id=net0".to_string(),
+                "-device".to_string(),
+                "virtio-net,netdev=net0".to_string(),
+            ],
+            category: SnippetCategory::Network,
+            description: Some("NAT user-mode networking with virtio-net".to_string()),
+        },
+        Snippet {
+            name: "tap network".to_string(),
+            args: vec![
+                "-netdev".to_string(),
+                "tap,id=net0".to_string(),
+                "-device".to_string(),
+                "virtio-net,netdev=net0".to_string(),
+            ],
+            category: SnippetCategory::Network,
+            description: Some("Bridged TAP networking with virtio-net".to_string()),
+        },
+        Snippet {
+            name: "no network".to_string(),
+            args: vec!["-net".to_string(), "none".to_string()],
+            category: SnippetCategory::Network,
+            description: Some("Disable all networking".to_string()),
+        },
+        Snippet {
+            name: "port forward 2222→22".to_string(),
+            args: vec![
+                "-netdev".to_string(),
+                "user,id=net0,hostfwd=tcp::2222-:22".to_string(),
+                "-device".to_string(),
+                "virtio-net,netdev=net0".to_string(),
+            ],
+            category: SnippetCategory::Network,
+            description: Some("Forward host TCP 2222 to guest SSH".to_string()),
+        },
+        // --- Display (5) ---
+        Snippet {
+            name: "no graphics".to_string(),
+            args: vec!["-nographic".to_string()],
+            category: SnippetCategory::Display,
+            description: Some("Disable graphics, use serial console".to_string()),
+        },
+        Snippet {
+            name: "no display".to_string(),
+            args: vec!["-display".to_string(), "none".to_string()],
+            category: SnippetCategory::Display,
+            description: Some("Run headless (no QEMU window)".to_string()),
+        },
+        Snippet {
+            name: "serial stdio".to_string(),
+            args: vec!["-serial".to_string(), "stdio".to_string()],
+            category: SnippetCategory::Display,
+            description: Some("Redirect serial port to terminal".to_string()),
+        },
+        Snippet {
+            name: "GTK display".to_string(),
+            args: vec!["-display".to_string(), "gtk".to_string()],
+            category: SnippetCategory::Display,
+            description: Some("Open a GTK window (Linux desktop)".to_string()),
+        },
+        Snippet {
+            name: "VNC server :0".to_string(),
+            args: vec!["-display".to_string(), "vnc=:0".to_string()],
+            category: SnippetCategory::Display,
+            description: Some("Serve display via VNC on port 5900".to_string()),
+        },
+        // --- Debug (5) ---
+        Snippet {
+            name: "enable gdbserver".to_string(),
+            args: vec!["-s".to_string()],
+            category: SnippetCategory::Debug,
+            description: Some("Listen for GDB on TCP 1234".to_string()),
+        },
+        Snippet {
+            name: "freeze on start".to_string(),
+            args: vec!["-S".to_string()],
+            category: SnippetCategory::Debug,
+            description: Some("Pause CPU until told to start (use with gdb)".to_string()),
+        },
+        Snippet {
+            name: "gdb + freeze".to_string(),
+            args: vec!["-s".to_string(), "-S".to_string()],
+            category: SnippetCategory::Debug,
+            description: Some("Wait for GDB before running any code".to_string()),
+        },
+        Snippet {
+            name: "QEMU monitor stdio".to_string(),
+            args: vec!["-monitor".to_string(), "stdio".to_string()],
+            category: SnippetCategory::Debug,
+            description: Some("Attach QEMU monitor to terminal".to_string()),
+        },
+        Snippet {
+            name: "log interrupts + resets".to_string(),
+            args: vec!["-d".to_string(), "int,cpu_reset".to_string()],
+            category: SnippetCategory::Debug,
+            description: Some("Trace interrupts and CPU resets".to_string()),
+        },
+        // --- Kernel (6) ---
+        Snippet {
+            name: "linux kernel".to_string(),
+            args: vec!["-kernel".to_string(), "vmlinuz".to_string()],
+            category: SnippetCategory::Kernel,
+            description: Some("Boot a Linux kernel image directly".to_string()),
+        },
+        Snippet {
+            name: "initrd".to_string(),
+            args: vec!["-initrd".to_string(), "initrd.img".to_string()],
+            category: SnippetCategory::Kernel,
+            description: Some("Provide an initial RAM disk".to_string()),
+        },
+        Snippet {
+            name: "device tree".to_string(),
+            args: vec!["-dtb".to_string(), "device.dtb".to_string()],
+            category: SnippetCategory::Kernel,
+            description: Some("Load a device tree blob".to_string()),
+        },
+        Snippet {
+            name: "kernel cmdline".to_string(),
+            args: vec!["-append".to_string(), "console=ttyS0".to_string()],
+            category: SnippetCategory::Kernel,
+            description: Some("Append kernel command line".to_string()),
+        },
+        Snippet {
+            name: "ARM serial cmdline".to_string(),
+            args: vec!["-append".to_string(), "console=ttyAMA0".to_string()],
+            category: SnippetCategory::Kernel,
+            description: Some("Console on ARM PL011 UART".to_string()),
+        },
+        Snippet {
+            name: "early printk".to_string(),
+            args: vec!["-append".to_string(), "earlyprintk=ttyS0".to_string()],
+            category: SnippetCategory::Kernel,
+            description: Some("Enable early kernel printk".to_string()),
+        },
+    ]
+}

--- a/src/snippets/mod.rs
+++ b/src/snippets/mod.rs
@@ -1,0 +1,7 @@
+pub mod builtin;
+pub mod storage;
+pub mod types;
+
+pub use builtin::builtin_snippets;
+pub use storage::{load_merged, load_user_snippets, save_user_snippets, snippets_file};
+pub use types::{Snippet, SnippetCategory, SnippetFile};

--- a/src/snippets/mod.rs
+++ b/src/snippets/mod.rs
@@ -1,7 +1,9 @@
 pub mod builtin;
 pub mod storage;
 pub mod types;
+pub mod validation;
 
 pub use builtin::builtin_snippets;
 pub use storage::{load_merged, load_user_snippets, save_user_snippets, snippets_file};
 pub use types::{Snippet, SnippetCategory, SnippetFile};
+pub use validation::validate_snippet_name;

--- a/src/snippets/storage.rs
+++ b/src/snippets/storage.rs
@@ -1,13 +1,33 @@
 use std::path::PathBuf;
 
 use super::types::{Snippet, SnippetFile};
-use crate::config::config_dir;
+use crate::config::{config_dir, vex_root_dir};
 use crate::error::{VexError, VexResult};
 
-/// Returns the user snippets file path: `$VEX_CONFIG_DIR/snippets.json`.
-/// Honors the `VEX_CONFIG_DIR` env var via the existing `config_dir()` helper.
+/// User snippets file at `<vex_root>/snippets.json`. Default mode:
+/// `~/.vex/snippets.json` (sibling to `configs/`).
 pub fn snippets_file() -> VexResult<PathBuf> {
-    Ok(config_dir()?.join("snippets.json"))
+    Ok(vex_root_dir()?.join("snippets.json"))
+}
+
+/// One-time migration of `~/.vex/configs/snippets.json` (0.4.1 GA) to
+/// `~/.vex/snippets.json`. Default mode only — env mode is a no-op
+/// because the two paths coincide.
+fn migrate_legacy_snippets_path() -> VexResult<()> {
+    let env_set = matches!(std::env::var("VEX_CONFIG_DIR"), Ok(v) if !v.is_empty());
+    if env_set {
+        return Ok(());
+    }
+    let new_path = snippets_file()?;
+    let old_path = config_dir()?.join("snippets.json");
+    if !new_path.exists() && old_path.exists() {
+        std::fs::rename(&old_path, &new_path).map_err(|e| VexError::IoError {
+            path: old_path,
+            operation: "migrate snippets.json from configs/".to_string(),
+            source: e,
+        })?;
+    }
+    Ok(())
 }
 
 /// Load user snippets from disk.
@@ -20,6 +40,7 @@ pub fn snippets_file() -> VexResult<PathBuf> {
 ///   crate::error::VexError; no new variant is introduced.)
 /// - `Err(VexError::IoError { .. })` on filesystem errors.
 pub fn load_user_snippets() -> VexResult<Vec<Snippet>> {
+    migrate_legacy_snippets_path()?;
     let path = snippets_file()?;
     if !path.exists() {
         return Ok(Vec::new());

--- a/src/snippets/storage.rs
+++ b/src/snippets/storage.rs
@@ -10,6 +10,22 @@ pub fn snippets_file() -> VexResult<PathBuf> {
     Ok(vex_root_dir()?.join("snippets.json"))
 }
 
+/// Pure migration step: rename `old` → `new` iff `new` doesn't exist
+/// and `old` does. Tested directly by the unit suite.
+pub(crate) fn migrate_snippets_if_needed(
+    old: &std::path::Path,
+    new: &std::path::Path,
+) -> VexResult<()> {
+    if !new.exists() && old.exists() {
+        std::fs::rename(old, new).map_err(|e| VexError::IoError {
+            path: old.to_path_buf(),
+            operation: "migrate snippets.json from configs/".to_string(),
+            source: e,
+        })?;
+    }
+    Ok(())
+}
+
 /// One-time migration of `~/.vex/configs/snippets.json` (0.4.1 GA) to
 /// `~/.vex/snippets.json`. Default mode only — env mode is a no-op
 /// because the two paths coincide.
@@ -20,14 +36,7 @@ fn migrate_legacy_snippets_path() -> VexResult<()> {
     }
     let new_path = snippets_file()?;
     let old_path = config_dir()?.join("snippets.json");
-    if !new_path.exists() && old_path.exists() {
-        std::fs::rename(&old_path, &new_path).map_err(|e| VexError::IoError {
-            path: old_path,
-            operation: "migrate snippets.json from configs/".to_string(),
-            source: e,
-        })?;
-    }
-    Ok(())
+    migrate_snippets_if_needed(&old_path, &new_path)
 }
 
 /// Load user snippets from disk.

--- a/src/snippets/storage.rs
+++ b/src/snippets/storage.rs
@@ -101,6 +101,9 @@ pub fn save_user_snippets(snippets: &[Snippet]) -> VexResult<()> {
         operation: "write snippets.json (tmp)".to_string(),
         source: e,
     })?;
+    // POSIX: atomic replace. Windows replace-safety pending (0.4.2, needs
+    // ReplaceFileW; tempfile::persist is not atomic on Windows either, and
+    // a remove-then-rename pattern would widen the data-loss window).
     std::fs::rename(&tmp, &path).map_err(|e| VexError::IoError {
         path: path.clone(),
         operation: "rename snippets.json".to_string(),

--- a/src/snippets/storage.rs
+++ b/src/snippets/storage.rs
@@ -1,0 +1,100 @@
+use std::path::PathBuf;
+
+use super::types::{Snippet, SnippetFile};
+use crate::config::config_dir;
+use crate::error::{VexError, VexResult};
+
+/// Returns the user snippets file path: `$VEX_CONFIG_DIR/snippets.json`.
+/// Honors the `VEX_CONFIG_DIR` env var via the existing `config_dir()` helper.
+pub fn snippets_file() -> VexResult<PathBuf> {
+    Ok(config_dir()?.join("snippets.json"))
+}
+
+/// Load user snippets from disk.
+///
+/// Returns:
+/// - `Ok(Vec::new())` when the file does not exist (fresh install).
+/// - `Ok(snippets)` on successful load.
+/// - `Err(VexError::ConfigParseFailed { .. })` when the file exists but
+///   is corrupt JSON. (Re-uses the existing path-less variant — see
+///   crate::error::VexError; no new variant is introduced.)
+/// - `Err(VexError::IoError { .. })` on filesystem errors.
+pub fn load_user_snippets() -> VexResult<Vec<Snippet>> {
+    let path = snippets_file()?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = std::fs::read_to_string(&path).map_err(|e| VexError::IoError {
+        path: path.clone(),
+        operation: "read snippets.json".to_string(),
+        source: e,
+    })?;
+    let file: SnippetFile =
+        serde_json::from_str(&content).map_err(|e| VexError::ConfigParseFailed { source: e })?;
+    Ok(file.snippets)
+}
+
+/// Load builtin + user snippets, merged. See `merge` for the merge contract.
+///
+/// User file errors (corrupt JSON, IO failure) propagate as `Err`. TUI
+/// callers should catch these and fall back to builtin-only with a
+/// user-facing message.
+pub fn load_merged() -> VexResult<Vec<Snippet>> {
+    let builtin = super::builtin::builtin_snippets();
+    let user = load_user_snippets()?;
+    Ok(merge(builtin, user))
+}
+
+/// Persist a slice of user snippets to `$VEX_CONFIG_DIR/snippets.json`.
+/// Atomically replaces the file via write-to-tempfile + rename.
+///
+/// Callers MUST pass user-defined snippets only; builtin entries would
+/// otherwise be saved as user entries and break the merge logic.
+pub fn save_user_snippets(snippets: &[Snippet]) -> VexResult<()> {
+    let path = snippets_file()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| VexError::IoError {
+            path: parent.to_path_buf(),
+            operation: "create snippets dir".to_string(),
+            source: e,
+        })?;
+    }
+    let file = SnippetFile {
+        schema_version: SnippetFile::CURRENT_VERSION,
+        snippets: snippets.to_vec(),
+    };
+    let json = serde_json::to_string_pretty(&file)
+        .map_err(|e| VexError::ConfigParseFailed { source: e })?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &json).map_err(|e| VexError::IoError {
+        path: tmp.clone(),
+        operation: "write snippets.json (tmp)".to_string(),
+        source: e,
+    })?;
+    std::fs::rename(&tmp, &path).map_err(|e| VexError::IoError {
+        path: path.clone(),
+        operation: "rename snippets.json".to_string(),
+        source: e,
+    })?;
+    Ok(())
+}
+
+/// Pure merge function — pub(crate) for unit testing.
+///
+/// Rules:
+/// 1. Start from `builtin` in its original order.
+/// 2. Each user snippet whose `name` matches a builtin replaces that
+///    builtin in place (preserving position).
+/// 3. User snippets whose `name` matches no builtin are appended at
+///    the end, in their original file order.
+pub(crate) fn merge(builtin: Vec<Snippet>, user: Vec<Snippet>) -> Vec<Snippet> {
+    let mut result = builtin;
+    for u in user {
+        if let Some(slot) = result.iter_mut().find(|b| b.name == u.name) {
+            *slot = u;
+        } else {
+            result.push(u);
+        }
+    }
+    result
+}

--- a/src/snippets/types.rs
+++ b/src/snippets/types.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// A single snippet — a named, categorised piece of QEMU args.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Snippet {
+    pub name: String,
+    pub args: Vec<String>,
+    pub category: SnippetCategory,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SnippetCategory {
+    Memory,
+    Cpu,
+    Machine,
+    Storage,
+    Network,
+    Display,
+    Debug,
+    Kernel,
+}
+
+/// On-disk schema for the user snippets file (`snippets.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnippetFile {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub snippets: Vec<Snippet>,
+}
+
+impl SnippetFile {
+    pub const CURRENT_VERSION: u32 = 1;
+}

--- a/src/snippets/validation.rs
+++ b/src/snippets/validation.rs
@@ -1,0 +1,37 @@
+use crate::error::{VexError, VexResult};
+
+const MAX_SNIPPET_NAME_LEN: usize = 64;
+
+/// Validate a snippet name. Snippet names are JSON fields inside
+/// `snippets.json`, never used as filenames, so the rules are
+/// deliberately more permissive than `validate_config_name`:
+///
+/// - non-empty after `trim`
+/// - at most 64 characters
+/// - no `char::is_control()` characters (covers `\n` `\r` `\t` `\0`)
+///
+/// Spaces, punctuation, and non-ASCII letters are all allowed — that
+/// is precisely what makes overrides of builtins like `"1G memory"`
+/// possible.
+pub fn validate_snippet_name(name: &str) -> VexResult<()> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(VexError::ValidationError {
+            field: Some("name".to_string()),
+            reason: "snippet name cannot be empty".to_string(),
+        });
+    }
+    if trimmed.chars().count() > MAX_SNIPPET_NAME_LEN {
+        return Err(VexError::ValidationError {
+            field: Some("name".to_string()),
+            reason: format!("snippet name too long (max {})", MAX_SNIPPET_NAME_LEN),
+        });
+    }
+    if trimmed.chars().any(|c| c.is_control()) {
+        return Err(VexError::ValidationError {
+            field: Some("name".to_string()),
+            reason: "snippet name cannot contain control characters".to_string(),
+        });
+    }
+    Ok(())
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,5 +16,6 @@ pub mod test_rename;
 pub mod test_resource;
 pub mod test_save;
 pub mod test_serde;
+pub mod test_snippets;
 pub mod test_tui;
 pub mod test_validation;

--- a/src/tests/test_snippets.rs
+++ b/src/tests/test_snippets.rs
@@ -1,0 +1,218 @@
+use crate::error::VexError;
+use crate::snippets::storage::merge;
+use crate::snippets::{
+    Snippet, SnippetCategory, SnippetFile, builtin_snippets, load_merged, load_user_snippets,
+};
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+/// Serializes tests that mutate the process-global `VEX_CONFIG_DIR` env
+/// var. Independent from the one in `tests::test_tui`; cross-module
+/// collisions are theoretically possible if both modules' env-tests race,
+/// but in practice the per-test windows are short and tempdirs are unique
+/// — flagged as a follow-up to extract a shared test-utils helper.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn set_config_dir(dir: &std::path::Path) {
+    // SAFETY: callers hold ENV_LOCK; only the snippets/refresh tests touch
+    // VEX_CONFIG_DIR in-process.
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir);
+    }
+}
+
+// --- Builtin library checks -----------------------------------------------
+
+#[test]
+fn builtin_snippets_count_is_42() {
+    assert_eq!(builtin_snippets().len(), 42);
+}
+
+#[test]
+fn builtin_snippets_unique_names() {
+    let names: Vec<String> = builtin_snippets().into_iter().map(|s| s.name).collect();
+    let unique: HashSet<&String> = names.iter().collect();
+    assert_eq!(
+        unique.len(),
+        names.len(),
+        "duplicate snippet names in builtin library"
+    );
+}
+
+#[test]
+fn builtin_snippets_category_counts() {
+    let all = builtin_snippets();
+    let count = |c: SnippetCategory| all.iter().filter(|s| s.category == c).count();
+    assert_eq!(count(SnippetCategory::Memory), 5);
+    assert_eq!(count(SnippetCategory::Cpu), 6);
+    assert_eq!(count(SnippetCategory::Machine), 4);
+    assert_eq!(count(SnippetCategory::Storage), 7);
+    assert_eq!(count(SnippetCategory::Network), 4);
+    assert_eq!(count(SnippetCategory::Display), 5);
+    assert_eq!(count(SnippetCategory::Debug), 5);
+    assert_eq!(count(SnippetCategory::Kernel), 6);
+}
+
+#[test]
+fn builtin_snippets_all_have_description() {
+    for s in builtin_snippets() {
+        let desc = s
+            .description
+            .as_ref()
+            .unwrap_or_else(|| panic!("snippet {:?} has no description", s.name));
+        assert!(
+            !desc.trim().is_empty(),
+            "snippet {:?} has empty description",
+            s.name
+        );
+    }
+}
+
+// --- Load tests (in-process VEX_CONFIG_DIR) -------------------------------
+
+#[test]
+fn load_user_snippets_returns_empty_when_file_missing() {
+    let _guard = lock_env();
+    let dir = tempfile::tempdir().unwrap();
+    set_config_dir(dir.path());
+    let result = load_user_snippets().unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn load_user_snippets_returns_err_on_corrupt_json() {
+    let _guard = lock_env();
+    let dir = tempfile::tempdir().unwrap();
+    set_config_dir(dir.path());
+    std::fs::write(dir.path().join("snippets.json"), "not valid json").unwrap();
+    let err = load_user_snippets().unwrap_err();
+    match err {
+        VexError::ConfigParseFailed { .. } => {}
+        other => panic!("expected ConfigParseFailed, got {:?}", other),
+    }
+}
+
+#[test]
+fn load_user_snippets_returns_parsed_when_valid() {
+    let _guard = lock_env();
+    let dir = tempfile::tempdir().unwrap();
+    set_config_dir(dir.path());
+
+    let file = SnippetFile {
+        schema_version: SnippetFile::CURRENT_VERSION,
+        snippets: vec![
+            Snippet {
+                name: "alpha".to_string(),
+                args: vec!["-m".to_string(), "512M".to_string()],
+                category: SnippetCategory::Memory,
+                description: None,
+            },
+            Snippet {
+                name: "beta".to_string(),
+                args: vec!["-smp".to_string(), "2".to_string()],
+                category: SnippetCategory::Cpu,
+                description: Some("two cores".to_string()),
+            },
+        ],
+    };
+    let json = serde_json::to_string(&file).unwrap();
+    std::fs::write(dir.path().join("snippets.json"), json).unwrap();
+
+    let loaded = load_user_snippets().unwrap();
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded[0].name, "alpha");
+    assert_eq!(loaded[1].name, "beta");
+}
+
+// --- Merge tests (pure, no IO) --------------------------------------------
+
+fn user_snippet(name: &str, category: SnippetCategory, args: Vec<&str>) -> Snippet {
+    Snippet {
+        name: name.to_string(),
+        args: args.into_iter().map(|s| s.to_string()).collect(),
+        category,
+        description: None,
+    }
+}
+
+#[test]
+fn merge_no_user_returns_only_builtin() {
+    let merged = merge(builtin_snippets(), Vec::new());
+    assert_eq!(merged.len(), 42);
+}
+
+#[test]
+fn merge_user_override_replaces_builtin_in_place() {
+    let user = vec![user_snippet(
+        "2G memory",
+        SnippetCategory::Memory,
+        vec!["-m", "2048M"],
+    )];
+    let merged = merge(builtin_snippets(), user);
+    assert_eq!(merged.len(), 42, "override must not change length");
+    let two_g = merged
+        .iter()
+        .find(|s| s.name == "2G memory")
+        .expect("override entry missing");
+    assert_eq!(two_g.args, vec!["-m".to_string(), "2048M".to_string()]);
+}
+
+#[test]
+fn merge_user_only_appended_at_end() {
+    let user = vec![user_snippet(
+        "my custom snippet",
+        SnippetCategory::Debug,
+        vec!["-trace", "events=on"],
+    )];
+    let merged = merge(builtin_snippets(), user);
+    assert_eq!(merged.len(), 43);
+    assert_eq!(merged.last().unwrap().name, "my custom snippet");
+}
+
+#[test]
+fn merge_preserves_builtin_order() {
+    let merged = merge(builtin_snippets(), Vec::new());
+    let head: Vec<&str> = merged.iter().take(5).map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        head,
+        vec![
+            "512M memory",
+            "1G memory",
+            "2G memory",
+            "4G memory",
+            "8G memory",
+        ]
+    );
+}
+
+#[test]
+fn load_merged_integration() {
+    let _guard = lock_env();
+    let dir = tempfile::tempdir().unwrap();
+    set_config_dir(dir.path());
+
+    let file = SnippetFile {
+        schema_version: SnippetFile::CURRENT_VERSION,
+        snippets: vec![
+            user_snippet("1G memory", SnippetCategory::Memory, vec!["-m", "1024M"]),
+            user_snippet("my unique", SnippetCategory::Debug, vec!["-d", "all"]),
+        ],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+
+    let merged = load_merged().unwrap();
+    assert_eq!(merged.len(), 43, "42 builtins minus 1 override + 2 user");
+    // Override applied:
+    let one_g = merged.iter().find(|s| s.name == "1G memory").unwrap();
+    assert_eq!(one_g.args, vec!["-m".to_string(), "1024M".to_string()]);
+    // Unique appended at end:
+    assert_eq!(merged.last().unwrap().name, "my unique");
+}

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -1931,14 +1931,20 @@ fn render_snippets_drawer_user_badge() {
     };
     let mut app = App::new(vec![entry]);
     app.handle_event(AppEvent::EnterEditExisting);
-    // Inject a user snippet into the drawer state.
+    // Inject a user snippet into the drawer state. Post-P4-10.4, the badge
+    // classifier reads user_only_snippets (membership), so we mirror the
+    // injection there to keep the fixture internally consistent — pushing
+    // only into the merged list would have produced a phantom "user" row
+    // that no on-disk source backs.
     let edit = app.edit.as_mut().unwrap();
-    edit.snippets.snippets.push(crate::snippets::Snippet {
+    let injected = crate::snippets::Snippet {
         name: "mycustom".to_string(),
         args: vec!["-X".to_string()],
         category: SnippetCategory::Debug,
         description: None,
-    });
+    };
+    edit.snippets.snippets.push(injected.clone());
+    edit.user_only_snippets.push(injected);
     let buf = render_to_buffer(&mut app, 140, 60);
     let s = buffer_to_string(&buf);
     assert!(s.contains("[user]"), "expected user badge: {}", s);

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -3084,3 +3084,103 @@ fn library_save_with_builtin_name_creates_override() {
     let msg = app.last_message.as_ref().expect("info expected");
     assert_eq!(msg.kind, MessageKind::Info);
 }
+
+// =========================================================================
+// P4-10.3: Override-manageability regression coverage
+// =========================================================================
+
+/// Seed snippets.json with one override whose name collides with a builtin
+/// (Cortex-A72 — the one builtin name that round-trips through
+/// validate_config_name). Returns the entered App.
+fn enter_library_with_cortex_override(dir: &std::path::Path) -> App {
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "Cortex-A72".to_string(),
+            args: vec!["-cpu".to_string(), "custom".to_string()],
+            category: crate::snippets::SnippetCategory::Cpu,
+            description: Some("user override".to_string()),
+        }],
+    };
+    std::fs::write(
+        dir.join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().unwrap();
+    let target_idx = lib
+        .snippets
+        .visible_rows()
+        .iter()
+        .position(|r| {
+            matches!(r, crate::tui::app::DrawerRow::Snippet { snippet_index }
+                if lib.snippets.snippets[*snippet_index].name == "Cortex-A72")
+        })
+        .expect("Cortex-A72 row visible");
+    app.library.as_mut().unwrap().snippets.selected = target_idx;
+    app
+}
+
+#[test]
+fn library_edit_override_with_builtin_name_allowed() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = enter_library_with_cortex_override(dir.path());
+    app.handle_event(AppEvent::LibraryEditSelected);
+    let lib = app.library.as_ref().unwrap();
+    let edit = lib
+        .edit
+        .as_ref()
+        .expect("edit must open for an override with a builtin name");
+    assert_eq!(edit.name.value, "Cortex-A72");
+    assert!(matches!(edit.mode, SnippetEditMode::Update { .. }));
+    assert!(
+        !matches!(app.last_message.as_ref().map(|m| m.kind), Some(MessageKind::Error)),
+        "must not error: {:?}",
+        app.last_message
+    );
+}
+
+#[test]
+fn library_delete_override_with_builtin_name_allowed() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = enter_library_with_cortex_override(dir.path());
+    app.handle_event(AppEvent::LibraryDeleteSelected);
+    let lib = app.library.as_ref().unwrap();
+    let confirm = lib
+        .delete_confirm
+        .as_ref()
+        .expect("delete confirm must open for an override with a builtin name");
+    assert_eq!(confirm.snippet_name, "Cortex-A72");
+    assert!(
+        !matches!(app.last_message.as_ref().map(|m| m.kind), Some(MessageKind::Error)),
+        "must not error: {:?}",
+        app.last_message
+    );
+}
+
+#[test]
+fn library_edit_pure_builtin_still_blocked() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    // Default selection is the Memory header (row 0); move down to first
+    // Memory snippet ("512M memory"), a pure builtin with no override.
+    app.handle_event(AppEvent::SnippetsDrawerDown);
+    app.handle_event(AppEvent::LibraryEditSelected);
+    let lib = app.library.as_ref().unwrap();
+    assert!(lib.edit.is_none(), "edit must NOT open for a pure builtin");
+    let msg = app
+        .last_message
+        .as_ref()
+        .expect("error message expected for pure builtin");
+    assert_eq!(msg.kind, MessageKind::Error);
+}

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -2695,13 +2695,7 @@ fn edit_token_char_input_modifies_buffer() {
     let mut app = enter_edit_args_field();
     app.handle_event(AppEvent::EditArgsEnterToken);
     app.handle_event(AppEvent::EditTokenChar('X'));
-    let token = app
-        .edit
-        .as_ref()
-        .unwrap()
-        .token_edit
-        .as_ref()
-        .unwrap();
+    let token = app.edit.as_ref().unwrap().token_edit.as_ref().unwrap();
     assert_eq!(token.value, "-mX");
 }
 
@@ -2722,13 +2716,7 @@ fn edit_token_backspace_deletes_from_buffer() {
     let mut app = enter_edit_args_field();
     app.handle_event(AppEvent::EditArgsEnterToken);
     app.handle_event(AppEvent::EditTokenBackspace);
-    let token = app
-        .edit
-        .as_ref()
-        .unwrap()
-        .token_edit
-        .as_ref()
-        .unwrap();
+    let token = app.edit.as_ref().unwrap().token_edit.as_ref().unwrap();
     assert_eq!(token.value, "-");
 }
 

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -3140,7 +3140,10 @@ fn library_edit_override_with_builtin_name_allowed() {
     assert_eq!(edit.name.value, "Cortex-A72");
     assert!(matches!(edit.mode, SnippetEditMode::Update { .. }));
     assert!(
-        !matches!(app.last_message.as_ref().map(|m| m.kind), Some(MessageKind::Error)),
+        !matches!(
+            app.last_message.as_ref().map(|m| m.kind),
+            Some(MessageKind::Error)
+        ),
         "must not error: {:?}",
         app.last_message
     );
@@ -3162,7 +3165,10 @@ fn library_delete_override_with_builtin_name_allowed() {
         .expect("delete confirm must open for an override with a builtin name");
     assert_eq!(confirm.snippet_name, "Cortex-A72");
     assert!(
-        !matches!(app.last_message.as_ref().map(|m| m.kind), Some(MessageKind::Error)),
+        !matches!(
+            app.last_message.as_ref().map(|m| m.kind),
+            Some(MessageKind::Error)
+        ),
         "must not error: {:?}",
         app.last_message
     );

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -3436,3 +3436,119 @@ fn library_pure_builtin_renders_as_builtin() {
         "pure builtin must not be classified as user-owned"
     );
 }
+
+// =========================================================================
+// P4-10.6: Library load-error read-only guard regression coverage
+// =========================================================================
+
+#[test]
+fn library_enter_with_corrupt_snippets_is_readonly() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // Garbage that snippets.json's serde_json::from_str will reject.
+    std::fs::write(dir.path().join("snippets.json"), b"{ not valid json").unwrap();
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().expect("library should be active");
+    assert!(
+        lib.load_error.is_some(),
+        "corrupt snippets.json must populate load_error"
+    );
+    assert!(
+        lib.user_only.is_empty(),
+        "user_only must stay empty when load fails"
+    );
+    let msg = app.last_message.as_ref().expect("error message expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+    assert!(
+        msg.text.contains("read-only"),
+        "user-facing message must explain read-only state: {}",
+        msg.text
+    );
+}
+
+/// THE data-safety regression. Without the read-only guard, save_snippet_edits
+/// would have written an empty `user_only` baseline back to disk, wiping the
+/// (currently corrupt but recoverable) file. This test asserts the disk
+/// content survives the attempted save byte-for-byte.
+#[test]
+fn library_save_blocked_after_load_error_preserves_disk() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let original_bytes: &[u8] = b"{ not valid json BUT MIGHT BE THE USER'S BACKUP";
+    std::fs::write(dir.path().join("snippets.json"), original_bytes).unwrap();
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    assert!(
+        app.library.as_ref().unwrap().load_error.is_some(),
+        "fixture sanity: load_error must be set"
+    );
+
+    // Open the snippet editor and type a valid override name, then save.
+    app.handle_event(AppEvent::LibraryNew);
+    for c in "Cortex-A72".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+
+    // The save must have been refused with a user-facing error.
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+    assert!(
+        msg.text.contains("snippets.json"),
+        "save error must mention the file: {}",
+        msg.text
+    );
+
+    // The hard guarantee: the original bytes on disk are untouched. If the
+    // guard ever regresses, save_user_snippets would have rewritten this
+    // file as `{"schema_version":1,"snippets":[...one entry...]}`.
+    let after = std::fs::read(dir.path().join("snippets.json")).unwrap();
+    assert_eq!(
+        after, original_bytes,
+        "snippets.json on disk must be byte-for-byte preserved when load failed"
+    );
+}
+
+#[test]
+fn library_enter_with_missing_file_is_writable() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // No snippets.json on disk — fresh install. Must NOT trigger read-only.
+    assert!(!dir.path().join("snippets.json").exists());
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    {
+        let lib = app.library.as_ref().expect("library active");
+        assert!(
+            lib.load_error.is_none(),
+            "missing file must not produce a load_error"
+        );
+    }
+
+    // Save path should succeed end-to-end.
+    app.handle_event(AppEvent::LibraryNew);
+    for c in "Cortex-A72".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+    let lib = app.library.as_ref().unwrap();
+    assert!(
+        lib.user_only.iter().any(|s| s.name == "Cortex-A72"),
+        "fresh-install save must succeed"
+    );
+    let msg = app.last_message.as_ref().expect("info expected");
+    assert_eq!(msg.kind, MessageKind::Info, "got: {:?}", msg);
+}

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -2965,3 +2965,122 @@ fn edit_rename_collision_keeps_old_and_new_files() {
         "taken.json must be untouched by a rejected rename"
     );
 }
+
+// =========================================================================
+// P4-10.2: Codex Round 2 regression coverage
+// =========================================================================
+
+#[test]
+fn edit_save_commits_active_token_edit() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = App::new(vec![]);
+    app.handle_event(AppEvent::EnterEditNew);
+    for c in "vm".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditFieldDown); // → QemuBin
+    for c in "/bin/true".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    // Jump straight to the Args field, open a token edit, type into it, and
+    // hit save WITHOUT first pressing Esc/Enter to commit the token.
+    app.handle_event(AppEvent::EditFieldDown); // → Description
+    app.handle_event(AppEvent::EditFieldDown); // → Args
+    app.handle_event(AppEvent::EditArgsAddEmpty);
+    for c in "-nographic".chars() {
+        app.handle_event(AppEvent::EditTokenChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+
+    assert!(app.edit.is_none(), "save should close edit");
+    // Reload from disk to confirm the token text reached storage.
+    let written = std::fs::read_to_string(dir.path().join("vm.json")).unwrap();
+    assert!(
+        written.contains("-nographic"),
+        "saved config must contain the in-flight token: {}",
+        written
+    );
+}
+
+#[test]
+fn snippets_file_uses_vex_root_not_configs() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    // Env mode: snippets_file() must NOT include a "configs" component.
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let env_path = crate::snippets::snippets_file().unwrap();
+    assert_eq!(env_path, dir.path().join("snippets.json"));
+    assert!(
+        !env_path.components().any(|c| c.as_os_str() == "configs"),
+        "env mode snippets path must not nest under configs/: {:?}",
+        env_path
+    );
+
+    // Default mode: still ends with .vex/snippets.json (no configs/).
+    unsafe {
+        std::env::remove_var("VEX_CONFIG_DIR");
+    }
+    let default_path = crate::snippets::snippets_file().unwrap();
+    assert!(
+        default_path.ends_with(".vex/snippets.json"),
+        "default snippets path must be ~/.vex/snippets.json: {:?}",
+        default_path
+    );
+}
+
+#[test]
+fn snippets_migrate_from_legacy_configs_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = dir.path().join("configs").join("snippets.json");
+    let new = dir.path().join("snippets.json");
+    std::fs::create_dir_all(old.parent().unwrap()).unwrap();
+    std::fs::write(&old, br#"{"schema_version":1,"snippets":[]}"#).unwrap();
+    assert!(!new.exists());
+
+    crate::snippets::storage::migrate_snippets_if_needed(&old, &new).unwrap();
+
+    assert!(new.exists(), "new path created by migration");
+    assert!(!old.exists(), "old path gone after rename");
+
+    // Second call is a no-op even though only `new` exists now.
+    crate::snippets::storage::migrate_snippets_if_needed(&old, &new).unwrap();
+    assert!(new.exists());
+}
+
+#[test]
+fn library_save_with_builtin_name_creates_override() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // "Cortex-A72" is the only builtin name that satisfies validate_config_name
+    // (no spaces). Typing it triggers the path the pre-Sub-3 guard rejected.
+    let mut app = enter_library_new();
+    for c in "Cortex-A72".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+
+    let lib = app.library.as_ref().expect("library still active");
+    assert!(lib.edit.is_none(), "save should close edit");
+    assert!(
+        lib.user_only.iter().any(|s| s.name == "Cortex-A72"),
+        "override must be present in user_only snapshot"
+    );
+    let content = std::fs::read_to_string(dir.path().join("snippets.json")).unwrap();
+    let parsed: crate::snippets::SnippetFile = serde_json::from_str(&content).unwrap();
+    assert!(
+        parsed.snippets.iter().any(|s| s.name == "Cortex-A72"),
+        "override must be persisted to disk: {}",
+        content
+    );
+    let msg = app.last_message.as_ref().expect("info expected");
+    assert_eq!(msg.kind, MessageKind::Info);
+}

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -2429,23 +2429,6 @@ fn snippet_edit_save_name_collision_sets_error() {
 }
 
 #[test]
-fn snippet_edit_save_builtin_name_sets_error() {
-    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    let dir = tempfile::tempdir().unwrap();
-    unsafe {
-        std::env::set_var("VEX_CONFIG_DIR", dir.path());
-    }
-    let mut app = enter_library_new();
-    for c in "1G memory".chars() {
-        app.handle_event(AppEvent::SnippetEditTextChar(c));
-    }
-    app.handle_event(AppEvent::SnippetEditSave);
-    assert!(app.library.as_ref().unwrap().edit.is_some());
-    let msg = app.last_message.as_ref().expect("error expected");
-    assert!(msg.text.contains("builtin name"));
-}
-
-#[test]
 fn snippet_edit_cancel_with_changes_enters_exit_confirm() {
     let mut app = enter_library_new();
     app.handle_event(AppEvent::SnippetEditTextChar('a'));

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -1,4 +1,7 @@
-use crate::tui::app::{App, BrowseSubMode, Focus, MessageKind};
+use crate::tui::app::{
+    App, BrowseSubMode, EditField, EditFocus, EditMode, EditState, ExitConfirm, Focus, MessageKind,
+    TextField,
+};
 use crate::tui::event::{AppEvent, translate_key};
 use crate::tui::scan::ConfigEntry;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
@@ -1153,5 +1156,1666 @@ fn tui_command_exits_cleanly_after_init() {
         !stderr.to_lowercase().contains("panic"),
         "stderr contained panic: {}",
         stderr
+    );
+}
+
+// =========================================================================
+// P4-7: Edit mode tests
+// =========================================================================
+
+// --- TextField unit tests -------------------------------------------------
+
+#[test]
+fn text_field_new_initial_cursor_at_end() {
+    let f = TextField::new("hello");
+    assert_eq!(f.value, "hello");
+    assert_eq!(f.cursor, 5);
+}
+
+#[test]
+fn text_field_insert_char_advances_cursor() {
+    let mut f = TextField::new("ab");
+    f.cursor = 1;
+    f.insert_char('X');
+    assert_eq!(f.value, "aXb");
+    assert_eq!(f.cursor, 2);
+}
+
+#[test]
+fn text_field_backspace_removes_prev_char() {
+    let mut f = TextField::new("abc");
+    f.cursor = 3;
+    f.backspace();
+    assert_eq!(f.value, "ab");
+    assert_eq!(f.cursor, 2);
+    f.cursor = 0;
+    f.backspace();
+    assert_eq!(f.value, "ab", "backspace at cursor=0 is no-op");
+}
+
+#[test]
+fn text_field_move_left_right_clamps() {
+    let mut f = TextField::new("ab");
+    f.cursor = 2;
+    f.move_right();
+    assert_eq!(f.cursor, 2);
+    f.move_left();
+    f.move_left();
+    f.move_left();
+    assert_eq!(f.cursor, 0);
+}
+
+#[test]
+fn text_field_handles_unicode() {
+    // "αβ" is 4 bytes total (2 bytes each in UTF-8). Cursor positions
+    // must align with char boundaries.
+    let mut f = TextField::new("αβ");
+    assert_eq!(f.cursor, 4);
+    f.backspace();
+    assert_eq!(f.value, "α");
+    assert_eq!(f.cursor, 2);
+    f.insert_char('γ');
+    assert_eq!(f.value, "αγ");
+    assert_eq!(f.cursor, 4);
+    f.move_left();
+    assert_eq!(f.cursor, 2);
+    f.move_left();
+    assert_eq!(f.cursor, 0);
+}
+
+// --- EditState tests -----------------------------------------------------
+
+fn ok_entry_for_edit(name: &str, qemu_bin: &str) -> crate::tui::scan::ConfigEntry {
+    use crate::config::QemuConfig;
+    crate::tui::scan::ConfigEntry::Ok {
+        name: name.to_string(),
+        config: QemuConfig {
+            qemu_bin: qemu_bin.to_string(),
+            args: vec!["-m".to_string(), "1G".to_string()],
+            desc: Some("hello".to_string()),
+            qemu_version: None,
+            resources: Default::default(),
+        },
+        path: std::path::PathBuf::from(format!("/tmp/{}.json", name)),
+    }
+}
+
+#[test]
+fn edit_from_config_clones_fields() {
+    use crate::config::QemuConfig;
+    let cfg = QemuConfig {
+        qemu_bin: "/usr/bin/qemu".to_string(),
+        args: vec!["-m".to_string(), "1G".to_string()],
+        desc: Some("hi".to_string()),
+        qemu_version: None,
+        resources: Default::default(),
+    };
+    let state = EditState::from_config(&cfg, "myvm");
+    assert_eq!(state.name.value, "myvm");
+    assert_eq!(state.qemu_bin.value, "/usr/bin/qemu");
+    assert_eq!(state.description.value, "hi");
+    assert_eq!(state.args, vec!["-m", "1G"]);
+    assert!(matches!(state.mode, EditMode::Update { .. }));
+    assert!(!state.dirty);
+}
+
+#[test]
+fn edit_new_empty_starts_at_name_field() {
+    let state = EditState::new_empty();
+    assert!(matches!(state.mode, EditMode::Create));
+    assert_eq!(state.focused_field, EditField::Name);
+    assert!(state.name.value.is_empty());
+    assert!(!state.dirty);
+}
+
+#[test]
+fn edit_tab_switches_pane() {
+    // P4-8: Tab now swaps Editor ↔ SnippetsDrawer; field cycling moved
+    // to ↑/↓ (EditFieldUp/EditFieldDown).
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    assert_eq!(app.edit.as_ref().unwrap().focus, EditFocus::Editor);
+    app.handle_event(AppEvent::EditTab);
+    assert_eq!(app.edit.as_ref().unwrap().focus, EditFocus::SnippetsDrawer);
+    app.handle_event(AppEvent::EditTab);
+    assert_eq!(app.edit.as_ref().unwrap().focus, EditFocus::Editor);
+}
+
+#[test]
+fn edit_shift_tab_switches_pane() {
+    // P4-8: Shift+Tab is equivalent to Tab in the 2-pane layout.
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditShiftTab);
+    assert_eq!(app.edit.as_ref().unwrap().focus, EditFocus::SnippetsDrawer);
+    app.handle_event(AppEvent::EditShiftTab);
+    assert_eq!(app.edit.as_ref().unwrap().focus, EditFocus::Editor);
+}
+
+#[test]
+fn edit_text_input_marks_dirty() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    assert!(!app.edit.as_ref().unwrap().dirty);
+    app.handle_event(AppEvent::EditTextChar('X'));
+    assert!(app.edit.as_ref().unwrap().dirty);
+}
+
+#[test]
+fn edit_args_move_up_swaps() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditFieldDown); // Name → QemuBin
+    app.handle_event(AppEvent::EditFieldDown); // → Description
+    app.handle_event(AppEvent::EditFieldDown); // → Args
+    // Args = ["-m", "1G"], selected = 0. Move down then up.
+    app.handle_event(AppEvent::EditArgsDown);
+    assert_eq!(app.edit.as_ref().unwrap().args_selected, 1);
+    app.handle_event(AppEvent::EditArgsMoveUp);
+    let edit = app.edit.as_ref().unwrap();
+    assert_eq!(edit.args, vec!["1G", "-m"]);
+    assert_eq!(edit.args_selected, 0);
+    assert!(edit.dirty);
+}
+
+#[test]
+fn edit_args_move_down_swaps() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditFieldDown);
+    app.handle_event(AppEvent::EditFieldDown);
+    app.handle_event(AppEvent::EditFieldDown);
+    app.handle_event(AppEvent::EditArgsMoveDown);
+    let edit = app.edit.as_ref().unwrap();
+    assert_eq!(edit.args, vec!["1G", "-m"]);
+    assert_eq!(edit.args_selected, 1);
+}
+
+#[test]
+fn edit_args_delete_decrements_selected_if_last() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditFieldDown);
+    app.handle_event(AppEvent::EditFieldDown);
+    app.handle_event(AppEvent::EditFieldDown);
+    app.handle_event(AppEvent::EditArgsDown); // selected = 1 (last)
+    app.handle_event(AppEvent::EditArgsDelete);
+    let edit = app.edit.as_ref().unwrap();
+    assert_eq!(edit.args, vec!["-m"]);
+    assert_eq!(
+        edit.args_selected, 0,
+        "deleting the last entry must clamp selection"
+    );
+}
+
+#[test]
+fn edit_cancel_without_changes_exits_immediately() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditCancel);
+    assert!(app.edit.is_none());
+}
+
+#[test]
+fn edit_cancel_with_changes_enters_exit_confirm() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditTextChar('X'));
+    app.handle_event(AppEvent::EditCancel);
+    let edit = app.edit.as_ref().expect("edit still active");
+    assert_eq!(edit.exit_confirm, Some(ExitConfirm::Pending));
+}
+
+#[test]
+fn edit_confirm_discard_exits() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditTextChar('X'));
+    app.handle_event(AppEvent::EditCancel);
+    app.handle_event(AppEvent::EditConfirmDiscard);
+    assert!(app.edit.is_none());
+}
+
+#[test]
+fn edit_confirm_cancel_returns_to_normal() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditTextChar('X'));
+    app.handle_event(AppEvent::EditCancel);
+    app.handle_event(AppEvent::EditConfirmCancel);
+    let edit = app.edit.as_ref().expect("edit still active");
+    assert_eq!(edit.exit_confirm, None);
+    assert!(edit.dirty);
+}
+
+#[test]
+fn edit_ctrl_c_during_edit_quits_and_discards() {
+    let mut app = App::new(vec![ok_entry_for_edit("a", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditTextChar('X'));
+    // Ctrl+C in translate_key maps to AppEvent::Quit; the Edit gate routes
+    // it through the special escape path.
+    app.handle_event(AppEvent::Quit);
+    assert!(app.should_quit);
+    assert!(app.edit.is_none());
+}
+
+// --- L2 Edit-pane render tests -------------------------------------------
+
+#[test]
+fn render_edit_pane_shows_editing_title() {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    let buf = render_to_buffer(&mut app, 120, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("Editing: alpha"), "buffer: {}", s);
+}
+
+#[test]
+fn render_edit_pane_focused_field_highlighted() {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    // Default focus = Name. The cursor block "█" must appear in the buffer
+    // since the Name field is focused.
+    let buf = render_to_buffer(&mut app, 120, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("█"), "expected cursor glyph: {}", s);
+    assert!(s.contains("Name"), "label expected: {}", s);
+}
+
+#[test]
+fn render_edit_pane_dirty_indicator_visible() {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditTextChar('X'));
+    let buf = render_to_buffer(&mut app, 120, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("unsaved"), "expected dirty indicator: {}", s);
+}
+
+#[test]
+fn render_edit_pane_exit_confirm_prompt() {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditTextChar('X'));
+    app.handle_event(AppEvent::EditCancel);
+    let buf = render_to_buffer(&mut app, 120, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("Save changes?"), "buffer: {}", s);
+    assert!(s.contains("[y] save"), "buffer: {}", s);
+    assert!(s.contains("[n] discard"), "buffer: {}", s);
+}
+
+#[test]
+fn render_top_bar_badge_changes_to_edit() {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    let buf = render_to_buffer(&mut app, 120, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("EDIT"), "expected EDIT badge: {}", s);
+    assert!(!s.contains("BROWSE"), "BROWSE badge must be hidden: {}", s);
+}
+
+// --- Save flow integration (uses tempdir + VEX_CONFIG_DIR) ---------------
+
+fn write_config_file(dir: &std::path::Path, name: &str, qemu_bin: &str) {
+    let json = format!(
+        r#"{{"qemu_bin":"{}","args":[],"desc":null,"qemu_version":null}}"#,
+        qemu_bin
+    );
+    std::fs::write(dir.join(format!("{}.json", name)), json).unwrap();
+}
+
+#[test]
+fn save_valid_config_writes_file_and_exits_edit() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    // SAFETY: env mutation serialized via ENV_LOCK above.
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = App::new(vec![]);
+    app.handle_event(AppEvent::EnterEditNew);
+    // Type a name and binary.
+    for c in "newvm".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditFieldDown); // → QemuBin
+    for c in "/bin/true".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+    assert!(app.edit.is_none(), "edit should close on successful save");
+    assert!(dir.path().join("newvm.json").exists());
+    // After save, entries should include the new config.
+    assert!(
+        app.entries.iter().any(
+            |e| matches!(e, crate::tui::scan::ConfigEntry::Ok { name, .. } if name == "newvm")
+        )
+    );
+    let msg = app.last_message.as_ref().expect("info message expected");
+    assert_eq!(msg.kind, MessageKind::Info);
+    assert!(msg.text.contains("Saved"));
+}
+
+#[test]
+fn save_invalid_name_keeps_edit_open_with_error() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = App::new(vec![]);
+    app.handle_event(AppEvent::EnterEditNew);
+    // Name with a path separator is invalid.
+    for c in "bad/name".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+    assert!(
+        app.edit.is_some(),
+        "edit must stay open on validation error"
+    );
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+}
+
+#[test]
+fn save_name_collision_in_create_mode_errors() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    write_config_file(dir.path(), "taken", "/bin/true");
+
+    let mut app = App::new(vec![]);
+    app.handle_event(AppEvent::EnterEditNew);
+    for c in "taken".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditFieldDown);
+    for c in "/bin/true".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+    assert!(app.edit.is_some());
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+    assert!(msg.text.contains("already exists"), "got: {}", msg.text);
+}
+
+#[test]
+fn save_rename_in_update_mode_removes_old_file() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    write_config_file(dir.path(), "old", "/bin/true");
+
+    use crate::tui::scan::ConfigEntry;
+    let entries = vec![ConfigEntry::Ok {
+        name: "old".to_string(),
+        config: crate::config::QemuConfig {
+            qemu_bin: "/bin/true".to_string(),
+            args: vec![],
+            desc: None,
+            qemu_version: None,
+            resources: Default::default(),
+        },
+        path: dir.path().join("old.json"),
+    }];
+    let mut app = App::new(entries);
+    app.handle_event(AppEvent::EnterEditExisting);
+    // Wipe name field and retype "new".
+    while app.edit.as_ref().unwrap().name.cursor > 0 {
+        app.handle_event(AppEvent::EditTextBackspace);
+    }
+    for c in "new".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+    assert!(app.edit.is_none());
+    assert!(!dir.path().join("old.json").exists(), "old file removed");
+    assert!(dir.path().join("new.json").exists(), "new file written");
+}
+
+#[test]
+fn save_preserves_resources_from_original_config() {
+    use crate::config::{QemuConfig, ResourceKind, ResourceRef};
+    use std::collections::HashMap;
+
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let target_path = dir.path().join("disk.img");
+    std::fs::write(&target_path, b"fake").unwrap();
+
+    let mut resources = HashMap::new();
+    resources.insert(
+        "disk".to_string(),
+        ResourceRef {
+            path: target_path.to_string_lossy().into_owned(),
+            kind: ResourceKind::Image,
+            sha256: None,
+            size: None,
+            url: None,
+        },
+    );
+    let original = QemuConfig {
+        qemu_bin: "/bin/true".to_string(),
+        args: vec![],
+        desc: None,
+        qemu_version: Some("9.0.0".to_string()),
+        resources,
+    };
+    // Write the original config first so storage / rescan sees it.
+    let json = serde_json::to_string_pretty(&original).unwrap();
+    std::fs::write(dir.path().join("withres.json"), json).unwrap();
+
+    use crate::tui::scan::ConfigEntry;
+    let entries = vec![ConfigEntry::Ok {
+        name: "withres".to_string(),
+        config: original.clone(),
+        path: dir.path().join("withres.json"),
+    }];
+    let mut app = App::new(entries);
+    app.handle_event(AppEvent::EnterEditExisting);
+    // Tweak description so save proceeds with a meaningful change.
+    app.handle_event(AppEvent::EditFieldDown);
+    app.handle_event(AppEvent::EditFieldDown); // → Description
+    for c in "new desc".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+    assert!(app.edit.is_none());
+
+    // Round-trip read from disk and verify the resources are still there.
+    let written = std::fs::read_to_string(dir.path().join("withres.json")).unwrap();
+    let parsed: QemuConfig = serde_json::from_str(&written).unwrap();
+    assert!(parsed.resources.contains_key("disk"));
+    assert_eq!(parsed.qemu_version.as_deref(), Some("9.0.0"));
+    assert_eq!(parsed.desc.as_deref(), Some("new desc"));
+}
+
+// =========================================================================
+// P4-8: Snippets drawer tests
+// =========================================================================
+
+use crate::snippets::SnippetCategory;
+use crate::tui::app::{DrawerRow, SnippetsDrawerState};
+
+fn enter_edit_with_snippets() -> App {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app
+}
+
+// --- L1 EditFocus / EditFieldUp / EditFieldDown -------------------------
+
+#[test]
+fn edit_field_up_cycles_backward() {
+    let mut app = enter_edit_with_snippets();
+    // From Name, ↑ → Args (prev cycle).
+    app.handle_event(AppEvent::EditFieldUp);
+    assert_eq!(app.edit.as_ref().unwrap().focused_field, EditField::Args);
+}
+
+#[test]
+fn edit_field_down_cycles_forward() {
+    let mut app = enter_edit_with_snippets();
+    app.handle_event(AppEvent::EditFieldDown);
+    assert_eq!(app.edit.as_ref().unwrap().focused_field, EditField::QemuBin);
+}
+
+#[test]
+fn edit_field_up_down_noop_in_snippets_focus() {
+    let mut app = enter_edit_with_snippets();
+    app.handle_event(AppEvent::EditTab); // → SnippetsDrawer
+    let before = app.edit.as_ref().unwrap().focused_field;
+    app.handle_event(AppEvent::EditFieldUp);
+    app.handle_event(AppEvent::EditFieldDown);
+    assert_eq!(app.edit.as_ref().unwrap().focused_field, before);
+}
+
+// --- L1 DrawerRow / visible_rows ----------------------------------------
+
+#[test]
+fn drawer_visible_rows_has_8_headers_when_no_filter() {
+    let drawer = SnippetsDrawerState::load();
+    let rows = drawer.visible_rows();
+    let header_count = rows
+        .iter()
+        .filter(|r| matches!(r, DrawerRow::CategoryHeader { .. }))
+        .count();
+    assert_eq!(header_count, 8);
+    // All 42 snippets are visible plus 8 headers = 50 total rows.
+    assert_eq!(rows.len(), 50);
+}
+
+#[test]
+fn drawer_visible_rows_collapsed_category_keeps_header() {
+    let mut drawer = SnippetsDrawerState::load();
+    drawer.collapsed.push(SnippetCategory::Memory);
+    let rows = drawer.visible_rows();
+    // Memory header should still appear, but no Memory snippet rows.
+    let memory_header_present = rows.iter().any(|r| {
+        matches!(
+            r,
+            DrawerRow::CategoryHeader {
+                category: SnippetCategory::Memory,
+                collapsed: true,
+                ..
+            }
+        )
+    });
+    assert!(memory_header_present);
+    let memory_snippets = rows
+        .iter()
+        .filter_map(|r| match r {
+            DrawerRow::Snippet { snippet_index } => Some(*snippet_index),
+            _ => None,
+        })
+        .filter(|idx| drawer.snippets[*idx].category == SnippetCategory::Memory)
+        .count();
+    assert_eq!(memory_snippets, 0);
+}
+
+#[test]
+fn drawer_visible_rows_filter_hides_unmatched_categories() {
+    let mut drawer = SnippetsDrawerState::load();
+    drawer.filter.active = true;
+    drawer.filter.query = TextField::new("alloc");
+    let rows = drawer.visible_rows();
+    // Only Memory descriptions contain "Allocate"; the rest should be hidden.
+    let categories: Vec<SnippetCategory> = rows
+        .iter()
+        .filter_map(|r| match r {
+            DrawerRow::CategoryHeader { category, .. } => Some(*category),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(categories.len(), 1);
+    assert!(categories.contains(&SnippetCategory::Memory));
+}
+
+#[test]
+fn drawer_visible_rows_filter_with_collapse() {
+    let mut drawer = SnippetsDrawerState::load();
+    drawer.filter.active = true;
+    drawer.filter.query = TextField::new("alloc");
+    drawer.collapsed.push(SnippetCategory::Memory);
+    let rows = drawer.visible_rows();
+    // Memory header present + collapsed, no snippets emitted.
+    assert_eq!(rows.len(), 1);
+    assert!(matches!(
+        &rows[0],
+        DrawerRow::CategoryHeader {
+            category: SnippetCategory::Memory,
+            collapsed: true,
+            ..
+        }
+    ));
+}
+
+// --- L1 Toggle collapse / clamp ----------------------------------------
+
+#[test]
+fn drawer_toggle_collapse_on_snippet_keeps_selected_on_header() {
+    let mut app = enter_edit_with_snippets();
+    app.handle_event(AppEvent::EditTab); // → SnippetsDrawer
+    // Move selection onto first Memory snippet (row 1 — header is row 0).
+    app.handle_event(AppEvent::SnippetsDrawerDown);
+    assert!(matches!(
+        app.edit.as_ref().unwrap().snippets.current_row(),
+        Some(DrawerRow::Snippet { .. })
+    ));
+    app.handle_event(AppEvent::SnippetsDrawerToggleCollapse);
+    // After collapse, selection should snap back onto the header row.
+    assert!(matches!(
+        app.edit.as_ref().unwrap().snippets.current_row(),
+        Some(DrawerRow::CategoryHeader {
+            category: SnippetCategory::Memory,
+            collapsed: true,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn drawer_toggle_collapse_on_header_unfolds_category() {
+    let mut app = enter_edit_with_snippets();
+    app.handle_event(AppEvent::EditTab);
+    // Currently selected = row 0 = Memory header (expanded). Collapse it.
+    app.handle_event(AppEvent::SnippetsDrawerToggleCollapse);
+    assert!(matches!(
+        app.edit.as_ref().unwrap().snippets.current_row(),
+        Some(DrawerRow::CategoryHeader {
+            collapsed: true,
+            ..
+        })
+    ));
+    // Toggle again → unfolds.
+    app.handle_event(AppEvent::SnippetsDrawerToggleCollapse);
+    assert!(matches!(
+        app.edit.as_ref().unwrap().snippets.current_row(),
+        Some(DrawerRow::CategoryHeader {
+            collapsed: false,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn drawer_clamp_selected_when_filter_changes() {
+    let mut drawer = SnippetsDrawerState::load();
+    drawer.selected = 40; // valid in unfiltered (50 rows)
+    drawer.filter.active = true;
+    drawer.filter.query = TextField::new("alloc");
+    drawer.clamp_selected();
+    let len = drawer.visible_rows().len();
+    assert!(drawer.selected < len);
+}
+
+// --- L1 Insert ---------------------------------------------------------
+
+#[test]
+fn drawer_insert_appends_to_empty_args() {
+    let mut app = App::new(vec![]);
+    app.handle_event(AppEvent::EnterEditNew);
+    app.handle_event(AppEvent::EditTab); // → SnippetsDrawer
+    // First visible row is Memory header; move down to the first snippet
+    // ("512M memory").
+    app.handle_event(AppEvent::SnippetsDrawerDown);
+    app.handle_event(AppEvent::SnippetsDrawerInsert);
+    let edit = app.edit.as_ref().unwrap();
+    assert_eq!(edit.args, vec!["-m", "512M"]);
+    assert!(edit.dirty);
+}
+
+#[test]
+fn drawer_insert_inserts_after_selected_position() {
+    // Start with args = ["-X", "-Y"], args_selected = 0.
+    use crate::config::QemuConfig;
+    let entry = crate::tui::scan::ConfigEntry::Ok {
+        name: "z".to_string(),
+        config: QemuConfig {
+            qemu_bin: "/bin/true".to_string(),
+            args: vec!["-X".to_string(), "-Y".to_string()],
+            desc: None,
+            qemu_version: None,
+            resources: Default::default(),
+        },
+        path: std::path::PathBuf::from("/tmp/z.json"),
+    };
+    let mut app = App::new(vec![entry]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditTab); // → SnippetsDrawer
+    app.handle_event(AppEvent::SnippetsDrawerDown); // → "512M memory"
+    app.handle_event(AppEvent::SnippetsDrawerInsert);
+    let edit = app.edit.as_ref().unwrap();
+    // args_selected was 0 → insert at index 1.
+    assert_eq!(edit.args, vec!["-X", "-m", "512M", "-Y"]);
+}
+
+#[test]
+fn drawer_insert_on_header_row_is_noop() {
+    let mut app = App::new(vec![]);
+    app.handle_event(AppEvent::EnterEditNew);
+    app.handle_event(AppEvent::EditTab);
+    // Selected row 0 = Memory header — Insert must do nothing.
+    let before = app.edit.as_ref().unwrap().args.clone();
+    app.handle_event(AppEvent::SnippetsDrawerInsert);
+    assert_eq!(app.edit.as_ref().unwrap().args, before);
+    assert!(!app.edit.as_ref().unwrap().dirty);
+}
+
+#[test]
+fn drawer_insert_marks_dirty() {
+    let mut app = App::new(vec![]);
+    app.handle_event(AppEvent::EnterEditNew);
+    app.handle_event(AppEvent::EditTab);
+    app.handle_event(AppEvent::SnippetsDrawerDown);
+    app.handle_event(AppEvent::SnippetsDrawerInsert);
+    assert!(app.edit.as_ref().unwrap().dirty);
+}
+
+// --- L2 render ----------------------------------------------------------
+
+#[test]
+fn render_edit_pane_shows_snippets_drawer() {
+    let mut app = enter_edit_with_snippets();
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("Snippets"), "buffer: {}", s);
+}
+
+#[test]
+fn render_snippets_drawer_shows_category_headers() {
+    let mut app = enter_edit_with_snippets();
+    let buf = render_to_buffer(&mut app, 140, 50);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("Memory"), "buffer: {}", s);
+    assert!(s.contains("Cpu"), "buffer: {}", s);
+}
+
+#[test]
+fn render_snippets_drawer_collapsed_chevron_visible() {
+    let mut app = enter_edit_with_snippets();
+    app.handle_event(AppEvent::EditTab);
+    app.handle_event(AppEvent::SnippetsDrawerToggleCollapse);
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    // ▶ (U+25B6) is the collapsed-chevron glyph; the suffix "(5 hidden)"
+    // also signals collapse.
+    assert!(s.contains("hidden"), "expected hidden suffix: {}", s);
+}
+
+#[test]
+fn render_snippets_drawer_user_badge() {
+    use crate::config::QemuConfig;
+    // Construct an edit state with an injected user snippet.
+    let entry = crate::tui::scan::ConfigEntry::Ok {
+        name: "u".to_string(),
+        config: QemuConfig {
+            qemu_bin: "/bin/true".to_string(),
+            args: vec![],
+            desc: None,
+            qemu_version: None,
+            resources: Default::default(),
+        },
+        path: std::path::PathBuf::from("/tmp/u.json"),
+    };
+    let mut app = App::new(vec![entry]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    // Inject a user snippet into the drawer state.
+    let edit = app.edit.as_mut().unwrap();
+    edit.snippets.snippets.push(crate::snippets::Snippet {
+        name: "my custom".to_string(),
+        args: vec!["-X".to_string()],
+        category: SnippetCategory::Debug,
+        description: None,
+    });
+    let buf = render_to_buffer(&mut app, 140, 60);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("[user]"), "expected user badge: {}", s);
+}
+
+// --- Integration: SnippetsDrawerState::load() ---------------------------
+
+#[test]
+fn drawer_load_merges_user_file_when_present() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // Write a user snippets file with one override + one unique entry.
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![
+            crate::snippets::Snippet {
+                name: "1G memory".to_string(),
+                args: vec!["-m".to_string(), "1024M".to_string()],
+                category: SnippetCategory::Memory,
+                description: None,
+            },
+            crate::snippets::Snippet {
+                name: "my unique".to_string(),
+                args: vec!["-z".to_string()],
+                category: SnippetCategory::Debug,
+                description: None,
+            },
+        ],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+
+    let drawer = SnippetsDrawerState::load();
+    assert!(drawer.load_error.is_none(), "expected clean load");
+    assert_eq!(
+        drawer.snippets.len(),
+        43,
+        "42 builtins minus 1 override + 2 user"
+    );
+}
+
+#[test]
+fn drawer_load_fallback_when_user_file_corrupt() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    std::fs::write(dir.path().join("snippets.json"), "not valid json").unwrap();
+
+    let drawer = SnippetsDrawerState::load();
+    assert!(
+        drawer.load_error.is_some(),
+        "expected load_error on corrupt file"
+    );
+    assert_eq!(drawer.snippets.len(), 42, "fall back to builtin-only");
+}
+
+// =========================================================================
+// P4-9: Library mode tests
+// =========================================================================
+
+use crate::tui::app::{DeleteConfirm, SnippetEditField, SnippetEditMode};
+
+// --- L1 LibraryState ----------------------------------------------------
+
+#[test]
+fn enter_library_initializes_state() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().expect("library should be active");
+    assert!(lib.edit.is_none());
+    assert!(lib.delete_confirm.is_none());
+    assert!(!lib.snippets.snippets.is_empty());
+}
+
+#[test]
+fn exit_library_clears_state() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    app.handle_event(AppEvent::ExitLibrary);
+    assert!(app.library.is_none());
+}
+
+#[test]
+fn library_disables_browse_events() {
+    let mut app = App::new(fixture_entries(3));
+    app.handle_event(AppEvent::EnterLibrary);
+    // Browse-only NavigateDown should not move the entries cursor.
+    let before = app.selected;
+    app.handle_event(AppEvent::NavigateDown);
+    assert_eq!(app.selected, before);
+}
+
+// --- L1 Library CRUD triggers -------------------------------------------
+
+#[test]
+fn library_new_opens_empty_edit() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    app.handle_event(AppEvent::LibraryNew);
+    let lib = app.library.as_ref().unwrap();
+    let s = lib.edit.as_ref().expect("snippet edit should be open");
+    assert!(matches!(s.mode, SnippetEditMode::Create));
+    assert!(s.name.value.is_empty());
+}
+
+#[test]
+fn library_edit_user_snippet_opens_edit() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // Pre-seed a user snippet on disk.
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "my custom".to_string(),
+            args: vec!["-X".to_string()],
+            category: crate::snippets::SnippetCategory::Debug,
+            description: None,
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    // Navigate to the "my custom" row — it's appended at the end (after
+    // 42 builtins). Headers are interleaved, so let's find it via the
+    // drawer's visible rows.
+    let lib = app.library.as_ref().unwrap();
+    let target_idx = lib
+        .snippets
+        .visible_rows()
+        .iter()
+        .position(|r| {
+            matches!(r, crate::tui::app::DrawerRow::Snippet { snippet_index }
+                if lib.snippets.snippets[*snippet_index].name == "my custom")
+        })
+        .expect("my custom should be visible");
+    app.library.as_mut().unwrap().snippets.selected = target_idx;
+    app.handle_event(AppEvent::LibraryEditSelected);
+    let lib = app.library.as_ref().unwrap();
+    let s = lib.edit.as_ref().expect("edit should be open");
+    assert_eq!(s.name.value, "my custom");
+    assert!(matches!(s.mode, SnippetEditMode::Update { .. }));
+}
+
+#[test]
+fn library_edit_builtin_snippet_sets_error() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    // Default selection is the Memory header (row 0); move down to first
+    // Memory snippet ("512M memory"), a builtin.
+    app.handle_event(AppEvent::SnippetsDrawerDown);
+    app.handle_event(AppEvent::LibraryEditSelected);
+    assert!(app.library.as_ref().unwrap().edit.is_none());
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+    assert!(msg.text.contains("builtin"));
+}
+
+#[test]
+fn library_delete_user_snippet_opens_confirm() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "to-delete".to_string(),
+            args: vec![],
+            category: crate::snippets::SnippetCategory::Debug,
+            description: None,
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().unwrap();
+    let target_idx = lib
+        .snippets
+        .visible_rows()
+        .iter()
+        .position(|r| {
+            matches!(r, crate::tui::app::DrawerRow::Snippet { snippet_index }
+                if lib.snippets.snippets[*snippet_index].name == "to-delete")
+        })
+        .unwrap();
+    app.library.as_mut().unwrap().snippets.selected = target_idx;
+    app.handle_event(AppEvent::LibraryDeleteSelected);
+    let lib = app.library.as_ref().unwrap();
+    let confirm = lib.delete_confirm.as_ref().expect("confirm open");
+    assert_eq!(confirm.snippet_name, "to-delete");
+}
+
+#[test]
+fn library_delete_builtin_snippet_sets_error() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    app.handle_event(AppEvent::SnippetsDrawerDown);
+    app.handle_event(AppEvent::LibraryDeleteSelected);
+    assert!(app.library.as_ref().unwrap().delete_confirm.is_none());
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+}
+
+#[test]
+fn library_delete_confirm_y_persists_and_reloads() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "delete-me".to_string(),
+            args: vec![],
+            category: crate::snippets::SnippetCategory::Debug,
+            description: None,
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    // Trigger delete confirm manually for simplicity.
+    app.library.as_mut().unwrap().delete_confirm = Some(DeleteConfirm {
+        snippet_index: 0,
+        snippet_name: "delete-me".to_string(),
+    });
+    app.handle_event(AppEvent::LibraryDeleteConfirm);
+    // Verify the file on disk no longer contains "delete-me".
+    let content = std::fs::read_to_string(dir.path().join("snippets.json")).unwrap();
+    assert!(
+        !content.contains("delete-me"),
+        "snippets.json should not contain deleted entry: {}",
+        content
+    );
+}
+
+#[test]
+fn library_delete_confirm_n_cancels() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    app.library.as_mut().unwrap().delete_confirm = Some(DeleteConfirm {
+        snippet_index: 0,
+        snippet_name: "x".to_string(),
+    });
+    app.handle_event(AppEvent::LibraryDeleteCancel);
+    assert!(app.library.as_ref().unwrap().delete_confirm.is_none());
+}
+
+// --- L1 SnippetEditState -------------------------------------------------
+
+fn enter_library_new() -> App {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    app.handle_event(AppEvent::LibraryNew);
+    app
+}
+
+#[test]
+fn snippet_edit_field_cycle() {
+    let mut app = enter_library_new();
+    let f0 = app
+        .library
+        .as_ref()
+        .unwrap()
+        .edit
+        .as_ref()
+        .unwrap()
+        .focused_field;
+    assert_eq!(f0, SnippetEditField::Name);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    assert_eq!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .focused_field,
+        SnippetEditField::Category
+    );
+    app.handle_event(AppEvent::SnippetEditFieldUp);
+    app.handle_event(AppEvent::SnippetEditFieldUp);
+    assert_eq!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .focused_field,
+        SnippetEditField::Args
+    );
+}
+
+#[test]
+fn snippet_edit_category_next_prev() {
+    let mut app = enter_library_new();
+    app.handle_event(AppEvent::SnippetEditCategoryNext);
+    assert_eq!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .category,
+        crate::snippets::SnippetCategory::Cpu
+    );
+    app.handle_event(AppEvent::SnippetEditCategoryPrev);
+    assert_eq!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .category,
+        crate::snippets::SnippetCategory::Memory
+    );
+}
+
+#[test]
+fn snippet_edit_text_input_marks_dirty() {
+    let mut app = enter_library_new();
+    app.handle_event(AppEvent::SnippetEditTextChar('a'));
+    assert!(app.library.as_ref().unwrap().edit.as_ref().unwrap().dirty);
+}
+
+#[test]
+fn snippet_edit_args_enter_token_opens_token_edit() {
+    let mut app = enter_library_new();
+    // Navigate to Args field, add an empty arg (auto-opens token edit).
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditArgsAddEmpty);
+    // Commit (Esc), then re-enter via Enter.
+    app.handle_event(AppEvent::SnippetEditTokenCommit);
+    app.handle_event(AppEvent::SnippetEditArgsEnterToken);
+    assert!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .token_edit
+            .is_some()
+    );
+}
+
+#[test]
+fn snippet_edit_token_commit_updates_args() {
+    let mut app = enter_library_new();
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditArgsAddEmpty);
+    // Type into the token buffer.
+    app.handle_event(AppEvent::SnippetEditTokenChar('-'));
+    app.handle_event(AppEvent::SnippetEditTokenChar('m'));
+    app.handle_event(AppEvent::SnippetEditTokenCommit);
+    let s = &app.library.as_ref().unwrap().edit.as_ref().unwrap();
+    assert_eq!(s.args, vec!["-m"]);
+    assert!(s.token_edit.is_none());
+}
+
+#[test]
+fn snippet_edit_token_cancel_discards() {
+    // commit_token_edit is the same as cancel in this prototype: both
+    // take() the buffer. We model "cancel" as "commit without applying" —
+    // here we just verify token_edit becomes None and args length stays
+    // the same after the new-arg auto-add path.
+    let mut app = enter_library_new();
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditArgsAddEmpty);
+    assert!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .token_edit
+            .is_some()
+    );
+    app.handle_event(AppEvent::SnippetEditTokenCommit);
+    assert!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .token_edit
+            .is_none()
+    );
+}
+
+#[test]
+fn snippet_edit_add_empty_arg_enters_token_edit() {
+    let mut app = enter_library_new();
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditFieldDown);
+    app.handle_event(AppEvent::SnippetEditArgsAddEmpty);
+    let s = app.library.as_ref().unwrap().edit.as_ref().unwrap();
+    assert_eq!(s.args.len(), 1);
+    assert!(s.token_edit.is_some());
+}
+
+#[test]
+fn snippet_edit_save_writes_file_and_reloads() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = enter_library_new();
+    // Type the name.
+    for c in "mysnip".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+    assert!(app.library.as_ref().unwrap().edit.is_none());
+    let content = std::fs::read_to_string(dir.path().join("snippets.json")).unwrap();
+    assert!(content.contains("mysnip"));
+}
+
+#[test]
+fn snippet_edit_save_name_collision_sets_error() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "taken".to_string(),
+            args: vec![],
+            category: crate::snippets::SnippetCategory::Debug,
+            description: None,
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+    let mut app = enter_library_new();
+    for c in "taken".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+    assert!(app.library.as_ref().unwrap().edit.is_some());
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+    assert!(msg.text.contains("already exists"));
+}
+
+#[test]
+fn snippet_edit_save_builtin_name_sets_error() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = enter_library_new();
+    for c in "1G memory".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+    assert!(app.library.as_ref().unwrap().edit.is_some());
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert!(msg.text.contains("builtin name"));
+}
+
+#[test]
+fn snippet_edit_cancel_with_changes_enters_exit_confirm() {
+    let mut app = enter_library_new();
+    app.handle_event(AppEvent::SnippetEditTextChar('a'));
+    app.handle_event(AppEvent::SnippetEditCancel);
+    assert_eq!(
+        app.library
+            .as_ref()
+            .unwrap()
+            .edit
+            .as_ref()
+            .unwrap()
+            .exit_confirm,
+        Some(crate::tui::app::ExitConfirm::Pending)
+    );
+}
+
+#[test]
+fn snippet_edit_confirm_discard_exits() {
+    let mut app = enter_library_new();
+    app.handle_event(AppEvent::SnippetEditTextChar('a'));
+    app.handle_event(AppEvent::SnippetEditCancel);
+    app.handle_event(AppEvent::SnippetEditConfirmDiscard);
+    assert!(app.library.as_ref().unwrap().edit.is_none());
+}
+
+// --- L2 render ----------------------------------------------------------
+
+#[test]
+fn render_library_pane_shows_tree_and_detail() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("Snippets Library"), "buffer: {}", s);
+    assert!(s.contains("Memory"), "buffer: {}", s);
+}
+
+#[test]
+fn render_library_pane_user_badge_in_detail() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "alpha-user".to_string(),
+            args: vec!["-Z".to_string()],
+            category: crate::snippets::SnippetCategory::Debug,
+            description: None,
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().unwrap();
+    let target = lib
+        .snippets
+        .visible_rows()
+        .iter()
+        .position(|r| {
+            matches!(r, crate::tui::app::DrawerRow::Snippet { snippet_index }
+                if lib.snippets.snippets[*snippet_index].name == "alpha-user")
+        })
+        .unwrap();
+    app.library.as_mut().unwrap().snippets.selected = target;
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("[user]"), "expected user badge: {}", s);
+    assert!(s.contains("snippets.json"), "expected source line: {}", s);
+}
+
+#[test]
+fn render_library_pane_builtin_source_readonly() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    // Move down to first builtin snippet.
+    app.handle_event(AppEvent::SnippetsDrawerDown);
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("builtin (read-only)"), "buffer: {}", s);
+}
+
+#[test]
+fn render_library_pane_in_snippet_edit_shows_editor() {
+    let mut app = enter_library_new();
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("Editing: new snippet"), "buffer: {}", s);
+}
+
+#[test]
+fn render_top_bar_library_badge() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("LIBRARY"), "expected LIBRARY badge: {}", s);
+}
+
+// --- Integration: full create/edit/delete roundtrips --------------------
+
+#[test]
+fn library_full_create_save_reload_roundtrip() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = enter_library_new();
+    for c in "newone".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+
+    // Read back and confirm the snippet survived a fresh load.
+    let drawer = crate::tui::app::SnippetsDrawerState::load();
+    assert!(drawer.snippets.iter().any(|s| s.name == "newone"));
+}
+
+#[test]
+fn library_full_edit_save_reload_roundtrip() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "before".to_string(),
+            args: vec!["-X".to_string()],
+            category: crate::snippets::SnippetCategory::Debug,
+            description: None,
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().unwrap();
+    let idx = lib
+        .snippets
+        .visible_rows()
+        .iter()
+        .position(|r| {
+            matches!(r, crate::tui::app::DrawerRow::Snippet { snippet_index }
+                if lib.snippets.snippets[*snippet_index].name == "before")
+        })
+        .unwrap();
+    app.library.as_mut().unwrap().snippets.selected = idx;
+    app.handle_event(AppEvent::LibraryEditSelected);
+    // Rename: delete "before", type "after".
+    for _ in 0.."before".len() {
+        app.handle_event(AppEvent::SnippetEditTextBackspace);
+    }
+    for c in "after".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+
+    let drawer = crate::tui::app::SnippetsDrawerState::load();
+    assert!(drawer.snippets.iter().any(|s| s.name == "after"));
+    assert!(!drawer.snippets.iter().any(|s| s.name == "before"));
+}
+
+#[test]
+fn library_full_delete_save_reload_roundtrip() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "doomed".to_string(),
+            args: vec![],
+            category: crate::snippets::SnippetCategory::Debug,
+            description: None,
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    app.library.as_mut().unwrap().delete_confirm = Some(DeleteConfirm {
+        snippet_index: 0,
+        snippet_name: "doomed".to_string(),
+    });
+    app.handle_event(AppEvent::LibraryDeleteConfirm);
+
+    let drawer = crate::tui::app::SnippetsDrawerState::load();
+    assert!(!drawer.snippets.iter().any(|s| s.name == "doomed"));
+}
+
+// =========================================================================
+// P4-10 subtask 1: args token edit in Edit mode
+// =========================================================================
+
+fn enter_edit_args_field() -> App {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.handle_event(AppEvent::EditFieldDown); // → QemuBin
+    app.handle_event(AppEvent::EditFieldDown); // → Description
+    app.handle_event(AppEvent::EditFieldDown); // → Args
+    app
+}
+
+#[test]
+fn edit_args_add_empty_inserts_and_enters_token_edit() {
+    let mut app = enter_edit_args_field();
+    let before_len = app.edit.as_ref().unwrap().args.len();
+    app.handle_event(AppEvent::EditArgsAddEmpty);
+    let edit = app.edit.as_ref().unwrap();
+    assert_eq!(edit.args.len(), before_len + 1);
+    assert!(edit.token_edit.is_some());
+    // Inserted at args_selected + 1 (new arg becomes the selection).
+    assert_eq!(edit.args[edit.args_selected], "");
+}
+
+#[test]
+fn edit_args_enter_token_opens_token_edit_with_current_value() {
+    let mut app = enter_edit_args_field();
+    // Default fixture args = ["-m", "1G"], selected = 0.
+    app.handle_event(AppEvent::EditArgsEnterToken);
+    let edit = app.edit.as_ref().unwrap();
+    let token = edit.token_edit.as_ref().expect("token_edit open");
+    assert_eq!(token.value, "-m");
+}
+
+#[test]
+fn edit_token_char_input_modifies_buffer() {
+    let mut app = enter_edit_args_field();
+    app.handle_event(AppEvent::EditArgsEnterToken);
+    app.handle_event(AppEvent::EditTokenChar('X'));
+    let token = app
+        .edit
+        .as_ref()
+        .unwrap()
+        .token_edit
+        .as_ref()
+        .unwrap();
+    assert_eq!(token.value, "-mX");
+}
+
+#[test]
+fn edit_token_commit_writes_back_to_args() {
+    let mut app = enter_edit_args_field();
+    app.handle_event(AppEvent::EditArgsEnterToken);
+    app.handle_event(AppEvent::EditTokenChar('!'));
+    app.handle_event(AppEvent::EditTokenCommit);
+    let edit = app.edit.as_ref().unwrap();
+    assert_eq!(edit.args[0], "-m!");
+    assert!(edit.token_edit.is_none());
+    assert!(edit.dirty);
+}
+
+#[test]
+fn edit_token_backspace_deletes_from_buffer() {
+    let mut app = enter_edit_args_field();
+    app.handle_event(AppEvent::EditArgsEnterToken);
+    app.handle_event(AppEvent::EditTokenBackspace);
+    let token = app
+        .edit
+        .as_ref()
+        .unwrap()
+        .token_edit
+        .as_ref()
+        .unwrap();
+    assert_eq!(token.value, "-");
+}
+
+#[test]
+fn edit_token_commit_clears_token_edit_state() {
+    let mut app = enter_edit_args_field();
+    app.handle_event(AppEvent::EditArgsAddEmpty);
+    assert!(app.edit.as_ref().unwrap().token_edit.is_some());
+    app.handle_event(AppEvent::EditTokenCommit);
+    assert!(app.edit.as_ref().unwrap().token_edit.is_none());
+}
+
+#[test]
+fn render_edit_args_token_edit_shows_cursor() {
+    let mut app = enter_edit_args_field();
+    app.handle_event(AppEvent::EditArgsEnterToken);
+    app.handle_event(AppEvent::EditTokenChar('Z'));
+    let buf = render_to_buffer(&mut app, 140, 30);
+    let s = buffer_to_string(&buf);
+    // The cursor glyph appears in the args list line for the edited token.
+    assert!(s.contains("█"), "expected cursor glyph: {}", s);
+    // The new token text appears too.
+    assert!(s.contains("-mZ"), "expected edited token text: {}", s);
+}
+
+// --- P4-10 subtask 2: help overlay completeness -------------------------
+
+#[test]
+fn render_help_browse_mode_contains_ctrl_l_library() {
+    let mut app = App::new(fixture_entries(1));
+    app.show_help = true;
+    let buf = render_to_buffer(&mut app, 80, 28);
+    let s = buffer_to_string(&buf);
+    assert!(
+        s.contains("Ctrl+L"),
+        "Browse help should mention Ctrl+L: {}",
+        s
+    );
+    assert!(s.contains("snippets library"), "buffer: {}", s);
+}
+
+#[test]
+fn render_help_edit_mode_contains_a_and_enter_token() {
+    let mut app = App::new(vec![ok_entry_for_edit("alpha", "/bin/true")]);
+    app.handle_event(AppEvent::EnterEditExisting);
+    app.show_help = true;
+    let buf = render_to_buffer(&mut app, 80, 28);
+    let s = buffer_to_string(&buf);
+    assert!(
+        s.contains("add empty arg"),
+        "Edit help should mention 'a' / add empty arg: {}",
+        s
+    );
+    assert!(
+        s.contains("edit selected arg token"),
+        "Edit help should mention Enter / edit token: {}",
+        s
+    );
+    assert!(
+        s.contains("Token edit"),
+        "Edit help should have a Token edit section: {}",
+        s
+    );
+}
+
+// --- P4-10 subtask 3: top bar consistency review -----------------------
+
+#[test]
+fn render_top_bar_library_to_edit_transition() {
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let buf = render_to_buffer(&mut app, 140, 28);
+    let s = buffer_to_string(&buf);
+    assert!(s.contains("LIBRARY"), "outer mode badge: {}", s);
+
+    // Open snippet edit → badge should flip to EDIT, stats to "Editing".
+    app.handle_event(AppEvent::LibraryNew);
+    let buf = render_to_buffer(&mut app, 140, 28);
+    let s = buffer_to_string(&buf);
+    assert!(
+        s.contains("EDIT"),
+        "nested sub-edit should swap badge to EDIT: {}",
+        s
+    );
+    assert!(
+        s.contains("Editing new snippet"),
+        "stats should reflect snippet edit: {}",
+        s
     );
 }

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -3198,6 +3198,115 @@ fn library_edit_pure_builtin_still_blocked() {
 }
 
 // =========================================================================
+// P4-10.5: Edit config-save regression coverage
+// =========================================================================
+
+#[test]
+fn config_save_strips_empty_args() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // Pre-existing config with two real args.
+    let original = crate::config::QemuConfig {
+        qemu_bin: "/bin/true".to_string(),
+        args: vec!["-m".to_string(), "1G".to_string()],
+        desc: None,
+        qemu_version: None,
+        resources: Default::default(),
+    };
+    let json = serde_json::to_string_pretty(&original).unwrap();
+    std::fs::write(dir.path().join("myvm.json"), json).unwrap();
+    let entries = vec![ConfigEntry::Ok {
+        name: "myvm".to_string(),
+        config: original.clone(),
+        path: dir.path().join("myvm.json"),
+    }];
+
+    let mut app = App::new(entries);
+    app.handle_event(AppEvent::EnterEditExisting);
+    // Navigate to the Args field and add an empty token (overlay opens but
+    // we do not type into it — the user "abandoned" the new row).
+    app.handle_event(AppEvent::EditFieldDown); // → QemuBin
+    app.handle_event(AppEvent::EditFieldDown); // → Description
+    app.handle_event(AppEvent::EditFieldDown); // → Args
+    app.handle_event(AppEvent::EditArgsAddEmpty);
+    // EditSave commits the empty token_edit into args first (P4-10.2 Sub-1)
+    // and then try_save_edit strips empties (Sub-1 of this round).
+    app.handle_event(AppEvent::EditSave);
+
+    let written = std::fs::read_to_string(dir.path().join("myvm.json")).unwrap();
+    let parsed: crate::config::QemuConfig = serde_json::from_str(&written).unwrap();
+    assert!(
+        !parsed.args.iter().any(|a| a.is_empty()),
+        "saved config must not contain empty arg tokens: {:?}",
+        parsed.args
+    );
+    assert!(
+        parsed.args.contains(&"-m".to_string()) && parsed.args.contains(&"1G".to_string()),
+        "real args must survive the strip: {:?}",
+        parsed.args
+    );
+}
+
+#[test]
+fn edit_save_reselects_within_active_filter() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // Three sibling configs whose names share the "cfg-" prefix.
+    for n in ["cfg-a", "cfg-b", "cfg-c"] {
+        write_config_file(dir.path(), n, "/bin/true");
+    }
+    let make_entry = |n: &str| ConfigEntry::Ok {
+        name: n.to_string(),
+        config: crate::config::QemuConfig {
+            qemu_bin: "/bin/true".to_string(),
+            args: vec![],
+            desc: None,
+            qemu_version: None,
+            resources: Default::default(),
+        },
+        path: dir.path().join(format!("{}.json", n)),
+    };
+    let mut app = App::new(vec![make_entry("cfg-a"), make_entry("cfg-b"), make_entry("cfg-c")]);
+    // Activate filter "cfg-" (matches all three), select cfg-b.
+    app.browse_sub = BrowseSubMode::Filtering {
+        query: "cfg-".to_string(),
+        accepted: true,
+    };
+    app.selected = 1;
+    app.handle_event(AppEvent::EnterEditExisting);
+    // Wipe name and rename to "renamed-x" — no longer matches "cfg-".
+    while app.edit.as_ref().unwrap().name.cursor > 0 {
+        app.handle_event(AppEvent::EditTextBackspace);
+    }
+    for c in "renamed-x".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+
+    // Post-save: entries are cfg-a, cfg-c, renamed-x (scan sorts by name).
+    // visible_indices under "cfg-" = positions of cfg-a (0) and cfg-c (1).
+    // Selection must be one of those — never the hidden renamed-x slot.
+    let visible = app.visible_indices();
+    assert!(
+        !visible.is_empty(),
+        "fixture sanity: cfg-a and cfg-c should still match the filter"
+    );
+    assert!(
+        visible.contains(&app.selected),
+        "selection {} must land on a visible row; visible={:?}, entries={:?}",
+        app.selected,
+        visible,
+        app.entries.iter().map(|e| e.name()).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
 // P4-10.4: Override data-flow regression coverage
 // =========================================================================
 

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -1934,7 +1934,7 @@ fn render_snippets_drawer_user_badge() {
     // Inject a user snippet into the drawer state.
     let edit = app.edit.as_mut().unwrap();
     edit.snippets.snippets.push(crate::snippets::Snippet {
-        name: "my custom".to_string(),
+        name: "mycustom".to_string(),
         args: vec!["-X".to_string()],
         category: SnippetCategory::Debug,
         description: None,
@@ -2063,7 +2063,7 @@ fn library_edit_user_snippet_opens_edit() {
     let file = crate::snippets::SnippetFile {
         schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
         snippets: vec![crate::snippets::Snippet {
-            name: "my custom".to_string(),
+            name: "mycustom".to_string(),
             args: vec!["-X".to_string()],
             category: crate::snippets::SnippetCategory::Debug,
             description: None,
@@ -2077,7 +2077,7 @@ fn library_edit_user_snippet_opens_edit() {
 
     let mut app = App::default();
     app.handle_event(AppEvent::EnterLibrary);
-    // Navigate to the "my custom" row — it's appended at the end (after
+    // Navigate to the "mycustom" row — it's appended at the end (after
     // 42 builtins). Headers are interleaved, so let's find it via the
     // drawer's visible rows.
     let lib = app.library.as_ref().unwrap();
@@ -2087,14 +2087,14 @@ fn library_edit_user_snippet_opens_edit() {
         .iter()
         .position(|r| {
             matches!(r, crate::tui::app::DrawerRow::Snippet { snippet_index }
-                if lib.snippets.snippets[*snippet_index].name == "my custom")
+                if lib.snippets.snippets[*snippet_index].name == "mycustom")
         })
         .expect("my custom should be visible");
     app.library.as_mut().unwrap().snippets.selected = target_idx;
     app.handle_event(AppEvent::LibraryEditSelected);
     let lib = app.library.as_ref().unwrap();
     let s = lib.edit.as_ref().expect("edit should be open");
-    assert_eq!(s.name.value, "my custom");
+    assert_eq!(s.name.value, "mycustom");
     assert!(matches!(s.mode, SnippetEditMode::Update { .. }));
 }
 
@@ -2805,5 +2805,180 @@ fn render_top_bar_library_to_edit_transition() {
         s.contains("Editing new snippet"),
         "stats should reflect snippet edit: {}",
         s
+    );
+}
+
+// =========================================================================
+// P4-10.1: Codex Round 1 regression coverage
+// =========================================================================
+
+/// Seed snippets.json with two overrides whose names collide with builtins
+/// plus one pure user entry. Reused by the save / delete regression tests.
+fn seed_overrides_and_pure_user(dir: &std::path::Path) {
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![
+            crate::snippets::Snippet {
+                name: "1G memory".to_string(),
+                args: vec!["-m".to_string(), "1024M".to_string()],
+                category: crate::snippets::SnippetCategory::Memory,
+                description: Some("override-1g".to_string()),
+            },
+            crate::snippets::Snippet {
+                name: "4G memory".to_string(),
+                args: vec!["-m".to_string(), "4096M".to_string()],
+                category: crate::snippets::SnippetCategory::Memory,
+                description: Some("override-4g".to_string()),
+            },
+            crate::snippets::Snippet {
+                name: "mycustom".to_string(),
+                args: vec!["-X".to_string()],
+                category: crate::snippets::SnippetCategory::Debug,
+                description: None,
+            },
+        ],
+    };
+    std::fs::write(
+        dir.join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn library_save_edit_preserves_other_overrides() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    seed_overrides_and_pure_user(dir.path());
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    // Edit the *pure user* entry. Pre-fix, save_snippet_edits rebuilt the
+    // user list by filtering merged through is_builtin_snippet_name, so the
+    // two builtin-name overrides would silently vanish after this save.
+    let target = crate::snippets::Snippet {
+        name: "mycustom".to_string(),
+        args: vec!["-X".to_string()],
+        category: crate::snippets::SnippetCategory::Debug,
+        description: Some("updated".to_string()),
+    };
+    let edit = crate::tui::app::SnippetEditState::from_snippet(&target);
+    app.library.as_mut().unwrap().edit = Some(edit);
+    app.handle_event(AppEvent::SnippetEditSave);
+
+    let content = std::fs::read_to_string(dir.path().join("snippets.json")).unwrap();
+    let parsed: crate::snippets::SnippetFile = serde_json::from_str(&content).unwrap();
+    let names: Vec<&str> = parsed.snippets.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"1G memory"),
+        "builtin-name override must survive an unrelated save: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"4G memory"),
+        "builtin-name override must survive an unrelated save: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"mycustom"),
+        "edited entry must remain: {:?}",
+        names
+    );
+    let edited = parsed
+        .snippets
+        .iter()
+        .find(|s| s.name == "mycustom")
+        .unwrap();
+    assert_eq!(edited.description.as_deref(), Some("updated"));
+}
+
+#[test]
+fn library_delete_preserves_other_overrides() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    seed_overrides_and_pure_user(dir.path());
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    // Bypass navigation: stage delete_confirm directly. snippet_index is
+    // unused by the handler post-Sub-3 (lookup is by name).
+    app.library.as_mut().unwrap().delete_confirm = Some(DeleteConfirm {
+        snippet_index: 0,
+        snippet_name: "1G memory".to_string(),
+    });
+    app.handle_event(AppEvent::LibraryDeleteConfirm);
+
+    let content = std::fs::read_to_string(dir.path().join("snippets.json")).unwrap();
+    let parsed: crate::snippets::SnippetFile = serde_json::from_str(&content).unwrap();
+    let names: Vec<&str> = parsed.snippets.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        !names.contains(&"1G memory"),
+        "deleted entry must be gone: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"4G memory"),
+        "other override must be preserved: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"mycustom"),
+        "pure user entry must be preserved: {:?}",
+        names
+    );
+}
+
+/// Sub-4 fallback A: collision-rejection preserves both files. Verifies the
+/// "rename rejected → old preserved" invariant on the Update path without
+/// having to mock a write failure.
+#[test]
+fn edit_rename_collision_keeps_old_and_new_files() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    // Two pre-existing configs: we'll try to rename "old" → "taken".
+    write_config_file(dir.path(), "old", "/bin/true");
+    let taken_marker = r#"{"qemu_bin":"/bin/marker","args":[],"desc":null,"qemu_version":null}"#;
+    std::fs::write(dir.path().join("taken.json"), taken_marker).unwrap();
+
+    let entries = vec![ConfigEntry::Ok {
+        name: "old".to_string(),
+        config: crate::config::QemuConfig {
+            qemu_bin: "/bin/true".to_string(),
+            args: vec![],
+            desc: None,
+            qemu_version: None,
+            resources: Default::default(),
+        },
+        path: dir.path().join("old.json"),
+    }];
+    let mut app = App::new(entries);
+    app.handle_event(AppEvent::EnterEditExisting);
+    while app.edit.as_ref().unwrap().name.cursor > 0 {
+        app.handle_event(AppEvent::EditTextBackspace);
+    }
+    for c in "taken".chars() {
+        app.handle_event(AppEvent::EditTextChar(c));
+    }
+    app.handle_event(AppEvent::EditSave);
+
+    // Edit stays open with an error; both files survive untouched.
+    assert!(app.edit.is_some(), "edit must stay open on collision");
+    let msg = app.last_message.as_ref().expect("error expected");
+    assert_eq!(msg.kind, MessageKind::Error);
+    assert!(msg.text.contains("already exists"), "got: {}", msg.text);
+    assert!(dir.path().join("old.json").exists(), "old file preserved");
+    let surviving = std::fs::read_to_string(dir.path().join("taken.json")).unwrap();
+    assert_eq!(
+        surviving, taken_marker,
+        "taken.json must be untouched by a rejected rename"
     );
 }

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -3196,3 +3196,130 @@ fn library_edit_pure_builtin_still_blocked() {
         .expect("error message expected for pure builtin");
     assert_eq!(msg.kind, MessageKind::Error);
 }
+
+// =========================================================================
+// P4-10.4: Override data-flow regression coverage
+// =========================================================================
+
+#[test]
+fn validate_snippet_name_accepts_spaces_and_punctuation() {
+    use crate::snippets::validate_snippet_name;
+    assert!(validate_snippet_name("1G memory").is_ok());
+    assert!(validate_snippet_name("no graphics").is_ok());
+    assert!(validate_snippet_name("Cortex-A72").is_ok());
+    assert!(validate_snippet_name("hello, world!").is_ok());
+
+    assert!(validate_snippet_name("").is_err());
+    assert!(validate_snippet_name("   ").is_err());
+    let long_name = "x".repeat(65);
+    assert!(validate_snippet_name(&long_name).is_err());
+    assert!(validate_snippet_name("name\nwith\nnewline").is_err());
+    assert!(validate_snippet_name("tab\there").is_err());
+    assert!(validate_snippet_name("nul\0byte").is_err());
+}
+
+/// THE space-named-builtin override test. Pre-P4-10.4 this would fail
+/// at try_save_snippet_edit because validate_config_name rejects spaces,
+/// even though "1G memory" is a perfectly valid snippet name on disk.
+/// Using "1G memory" here — NOT Cortex-A72 — is the whole point: it
+/// closes the blind spot the prior round only happened to skirt.
+#[test]
+fn library_save_override_for_space_named_builtin() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let mut app = enter_library_new();
+    for c in "1G memory".chars() {
+        app.handle_event(AppEvent::SnippetEditTextChar(c));
+    }
+    app.handle_event(AppEvent::SnippetEditSave);
+
+    let lib = app.library.as_ref().expect("library still active");
+    assert!(lib.edit.is_none(), "save should close edit");
+    assert!(
+        lib.user_only.iter().any(|s| s.name == "1G memory"),
+        "override must be in user_only snapshot"
+    );
+    let content = std::fs::read_to_string(dir.path().join("snippets.json")).unwrap();
+    let parsed: crate::snippets::SnippetFile = serde_json::from_str(&content).unwrap();
+    assert!(
+        parsed.snippets.iter().any(|s| s.name == "1G memory"),
+        "override must be persisted to disk: {}",
+        content
+    );
+    let msg = app.last_message.as_ref().expect("info expected");
+    assert_eq!(msg.kind, MessageKind::Info, "expected info, got {:?}", msg);
+}
+
+#[test]
+fn library_override_renders_as_user_not_builtin() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![crate::snippets::Snippet {
+            name: "1G memory".to_string(),
+            args: vec!["-m".to_string(), "1024M".to_string()],
+            category: crate::snippets::SnippetCategory::Memory,
+            description: Some("user override".to_string()),
+        }],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().unwrap();
+    let snippet = lib
+        .snippets
+        .snippets
+        .iter()
+        .find(|s| s.name == "1G memory")
+        .expect("override visible in merged list");
+    let is_user_owned = lib.user_only.iter().any(|u| u.name == snippet.name);
+    assert!(
+        is_user_owned,
+        "membership classifier must mark the override as user-owned"
+    );
+}
+
+#[test]
+fn library_pure_builtin_renders_as_builtin() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("VEX_CONFIG_DIR", dir.path());
+    }
+    let file = crate::snippets::SnippetFile {
+        schema_version: crate::snippets::SnippetFile::CURRENT_VERSION,
+        snippets: vec![],
+    };
+    std::fs::write(
+        dir.path().join("snippets.json"),
+        serde_json::to_string(&file).unwrap(),
+    )
+    .unwrap();
+
+    let mut app = App::default();
+    app.handle_event(AppEvent::EnterLibrary);
+    let lib = app.library.as_ref().unwrap();
+    let snippet = lib
+        .snippets
+        .snippets
+        .iter()
+        .find(|s| s.name == "no graphics")
+        .expect("pure builtin must be present in merged list");
+    let is_user_owned = lib.user_only.iter().any(|u| u.name == snippet.name);
+    assert!(
+        !is_user_owned,
+        "pure builtin must not be classified as user-owned"
+    );
+}

--- a/src/tests/test_tui.rs
+++ b/src/tests/test_tui.rs
@@ -3272,7 +3272,11 @@ fn edit_save_reselects_within_active_filter() {
         },
         path: dir.path().join(format!("{}.json", n)),
     };
-    let mut app = App::new(vec![make_entry("cfg-a"), make_entry("cfg-b"), make_entry("cfg-c")]);
+    let mut app = App::new(vec![
+        make_entry("cfg-a"),
+        make_entry("cfg-b"),
+        make_entry("cfg-c"),
+    ]);
     // Activate filter "cfg-" (matches all three), select cfg-b.
     app.browse_sub = BrowseSubMode::Filtering {
         query: "cfg-".to_string(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,6 @@
 use super::event::AppEvent;
 use super::scan::{self, ConfigEntry};
+use crate::config::QemuConfig;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Focus {
@@ -33,6 +34,554 @@ pub enum BrowseSubMode {
     },
 }
 
+/// Identifies which field has keyboard focus in Edit mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditField {
+    Name,
+    QemuBin,
+    Description,
+    Args,
+}
+
+impl EditField {
+    /// Tab forward cycle: Name → QemuBin → Description → Args → Name → …
+    pub fn next(self) -> Self {
+        match self {
+            EditField::Name => EditField::QemuBin,
+            EditField::QemuBin => EditField::Description,
+            EditField::Description => EditField::Args,
+            EditField::Args => EditField::Name,
+        }
+    }
+
+    /// Shift+Tab backward cycle.
+    pub fn prev(self) -> Self {
+        match self {
+            EditField::Name => EditField::Args,
+            EditField::QemuBin => EditField::Name,
+            EditField::Description => EditField::QemuBin,
+            EditField::Args => EditField::Description,
+        }
+    }
+}
+
+/// A single-line text input with cursor support. Cursor is a byte
+/// offset into `value` and is always kept on a char boundary by every
+/// mutator on this type.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TextField {
+    pub value: String,
+    pub cursor: usize,
+}
+
+impl TextField {
+    pub fn new(initial: &str) -> Self {
+        Self {
+            value: initial.to_string(),
+            cursor: initial.len(),
+        }
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        self.value.insert(self.cursor, c);
+        self.cursor += c.len_utf8();
+    }
+
+    pub fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let mut new_cursor = self.cursor - 1;
+        while new_cursor > 0 && !self.value.is_char_boundary(new_cursor) {
+            new_cursor -= 1;
+        }
+        self.value.replace_range(new_cursor..self.cursor, "");
+        self.cursor = new_cursor;
+    }
+
+    pub fn move_left(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let mut new_cursor = self.cursor - 1;
+        while new_cursor > 0 && !self.value.is_char_boundary(new_cursor) {
+            new_cursor -= 1;
+        }
+        self.cursor = new_cursor;
+    }
+
+    pub fn move_right(&mut self) {
+        if self.cursor >= self.value.len() {
+            return;
+        }
+        let mut new_cursor = self.cursor + 1;
+        while new_cursor < self.value.len() && !self.value.is_char_boundary(new_cursor) {
+            new_cursor += 1;
+        }
+        self.cursor = new_cursor;
+    }
+}
+
+/// Whether the current Edit session creates a new configuration or
+/// updates an existing one. `Update` carries the original name so rename
+/// detection on save can locate the old file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditMode {
+    Create,
+    Update { original_name: String },
+}
+
+/// Sentinel for an in-progress "discard unsaved changes?" prompt.
+/// Only one variant today; left as an enum for forward-compat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitConfirm {
+    Pending,
+}
+
+/// Which large pane has keyboard focus in Edit mode.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum EditFocus {
+    #[default]
+    Editor,
+    SnippetsDrawer,
+}
+
+/// One row of the Snippets drawer display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DrawerRow {
+    CategoryHeader {
+        category: crate::snippets::SnippetCategory,
+        collapsed: bool,
+        snippet_count: usize,
+    },
+    Snippet {
+        snippet_index: usize,
+    },
+}
+
+/// Snippets-drawer filter input state.
+#[derive(Debug, Clone, Default)]
+pub struct SnippetFilter {
+    pub active: bool,
+    pub query: TextField,
+}
+
+/// State of the Snippets drawer (right pane of Edit mode).
+#[derive(Debug, Clone)]
+pub struct SnippetsDrawerState {
+    pub snippets: Vec<crate::snippets::Snippet>,
+    pub load_error: Option<String>,
+    pub selected: usize,
+    /// Categories the user has collapsed. Stored as a Vec (max 8 entries,
+    /// linear lookup is fine) because SnippetCategory doesn't derive Hash
+    /// and the snippets module is read-only at this phase.
+    pub collapsed: Vec<crate::snippets::SnippetCategory>,
+    pub filter: SnippetFilter,
+}
+
+impl SnippetsDrawerState {
+    /// Load merged snippets. On user-file error, fall back to builtin
+    /// and remember the error so the drawer title can surface it.
+    pub fn load() -> Self {
+        match crate::snippets::load_merged() {
+            Ok(snippets) => Self {
+                snippets,
+                load_error: None,
+                selected: 0,
+                collapsed: Vec::new(),
+                filter: SnippetFilter::default(),
+            },
+            Err(e) => Self {
+                snippets: crate::snippets::builtin_snippets(),
+                load_error: Some(format!("User snippets unavailable: {}", e)),
+                selected: 0,
+                collapsed: Vec::new(),
+                filter: SnippetFilter::default(),
+            },
+        }
+    }
+
+    fn is_collapsed(&self, cat: &crate::snippets::SnippetCategory) -> bool {
+        self.collapsed.contains(cat)
+    }
+
+    fn toggle_collapse(&mut self, cat: crate::snippets::SnippetCategory) {
+        if let Some(idx) = self.collapsed.iter().position(|c| *c == cat) {
+            self.collapsed.remove(idx);
+        } else {
+            self.collapsed.push(cat);
+        }
+    }
+
+    /// Ordered list of display rows. Includes a CategoryHeader for every
+    /// category that has at least one (filter-matched) snippet; if the
+    /// category is not collapsed, also emits its snippet rows.
+    pub fn visible_rows(&self) -> Vec<DrawerRow> {
+        use crate::snippets::SnippetCategory;
+        let categories = [
+            SnippetCategory::Memory,
+            SnippetCategory::Cpu,
+            SnippetCategory::Machine,
+            SnippetCategory::Storage,
+            SnippetCategory::Network,
+            SnippetCategory::Display,
+            SnippetCategory::Debug,
+            SnippetCategory::Kernel,
+        ];
+
+        let q = if self.filter.active && !self.filter.query.value.is_empty() {
+            Some(self.filter.query.value.to_lowercase())
+        } else {
+            None
+        };
+
+        let snippet_matches = |s: &crate::snippets::Snippet| -> bool {
+            let Some(q) = &q else { return true };
+            if s.name.to_lowercase().contains(q) {
+                return true;
+            }
+            s.description
+                .as_ref()
+                .map(|d| d.to_lowercase().contains(q))
+                .unwrap_or(false)
+        };
+
+        let mut rows = Vec::new();
+        for cat in &categories {
+            let cat_snippets: Vec<(usize, &crate::snippets::Snippet)> = self
+                .snippets
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| s.category == *cat)
+                .collect();
+            let total_count = cat_snippets.len();
+            if total_count == 0 {
+                continue;
+            }
+            let matching: Vec<(usize, &crate::snippets::Snippet)> = cat_snippets
+                .into_iter()
+                .filter(|(_, s)| snippet_matches(s))
+                .collect();
+            if q.is_some() && matching.is_empty() {
+                continue;
+            }
+
+            let collapsed = self.is_collapsed(cat);
+            rows.push(DrawerRow::CategoryHeader {
+                category: *cat,
+                collapsed,
+                snippet_count: total_count,
+            });
+            if !collapsed {
+                for (idx, _) in matching {
+                    rows.push(DrawerRow::Snippet { snippet_index: idx });
+                }
+            }
+        }
+        rows
+    }
+
+    pub fn current_row(&self) -> Option<DrawerRow> {
+        self.visible_rows().get(self.selected).cloned()
+    }
+
+    pub fn current_snippet(&self) -> Option<&crate::snippets::Snippet> {
+        match self.current_row()? {
+            DrawerRow::Snippet { snippet_index } => self.snippets.get(snippet_index),
+            DrawerRow::CategoryHeader { .. } => None,
+        }
+    }
+
+    pub fn clamp_selected(&mut self) {
+        let len = self.visible_rows().len();
+        if len == 0 {
+            self.selected = 0;
+        } else if self.selected >= len {
+            self.selected = len - 1;
+        }
+    }
+}
+
+/// In-progress edit session buffer.
+#[derive(Debug, Clone)]
+pub struct EditState {
+    pub mode: EditMode,
+    pub name: TextField,
+    pub qemu_bin: TextField,
+    pub description: TextField,
+    pub args: Vec<String>,
+    pub focused_field: EditField,
+    pub args_selected: usize,
+    pub dirty: bool,
+    pub exit_confirm: Option<ExitConfirm>,
+    /// Which large pane has focus: Editor (text fields + args list) or
+    /// SnippetsDrawer.
+    pub focus: EditFocus,
+    /// Snippets drawer state.
+    pub snippets: SnippetsDrawerState,
+    /// When `Some`, the currently-selected arg in the Args field is being
+    /// edited in place via a TextField overlay. Set by `EditArgsAddEmpty`
+    /// or `EditArgsEnterToken`; committed back to `args[args_selected]`
+    /// by `commit_token_edit()`.
+    pub token_edit: Option<TextField>,
+    /// Original resources & qemu_version preserved so Update-mode save
+    /// doesn't drop fields P4-7 doesn't yet edit.
+    pub(crate) preserved_resources: std::collections::HashMap<String, crate::config::ResourceRef>,
+    pub(crate) preserved_qemu_version: Option<String>,
+
+    // Snapshots for dirty detection.
+    initial_name: String,
+    initial_qemu_bin: String,
+    initial_description: String,
+    initial_args: Vec<String>,
+}
+
+impl EditState {
+    pub fn from_config(config: &QemuConfig, name: &str) -> Self {
+        let description = config.desc.clone().unwrap_or_default();
+        Self {
+            mode: EditMode::Update {
+                original_name: name.to_string(),
+            },
+            name: TextField::new(name),
+            qemu_bin: TextField::new(&config.qemu_bin),
+            description: TextField::new(&description),
+            args: config.args.clone(),
+            focused_field: EditField::Name,
+            args_selected: 0,
+            dirty: false,
+            exit_confirm: None,
+            focus: EditFocus::Editor,
+            snippets: SnippetsDrawerState::load(),
+            token_edit: None,
+            preserved_resources: config.resources.clone(),
+            preserved_qemu_version: config.qemu_version.clone(),
+            initial_name: name.to_string(),
+            initial_qemu_bin: config.qemu_bin.clone(),
+            initial_description: description,
+            initial_args: config.args.clone(),
+        }
+    }
+
+    pub fn new_empty() -> Self {
+        Self {
+            mode: EditMode::Create,
+            name: TextField::default(),
+            qemu_bin: TextField::default(),
+            description: TextField::default(),
+            args: Vec::new(),
+            focused_field: EditField::Name,
+            args_selected: 0,
+            dirty: false,
+            exit_confirm: None,
+            focus: EditFocus::Editor,
+            snippets: SnippetsDrawerState::load(),
+            token_edit: None,
+            preserved_resources: std::collections::HashMap::new(),
+            preserved_qemu_version: None,
+            initial_name: String::new(),
+            initial_qemu_bin: String::new(),
+            initial_description: String::new(),
+            initial_args: Vec::new(),
+        }
+    }
+
+    pub fn recompute_dirty(&mut self) {
+        self.dirty = self.name.value != self.initial_name
+            || self.qemu_bin.value != self.initial_qemu_bin
+            || self.description.value != self.initial_description
+            || self.args != self.initial_args;
+    }
+
+    /// Commit the current `token_edit` buffer back into `args[args_selected]`
+    /// and clear `token_edit`. No-op when `token_edit` is `None`.
+    pub fn commit_token_edit(&mut self) {
+        if let Some(token) = self.token_edit.take()
+            && self.args_selected < self.args.len()
+        {
+            self.args[self.args_selected] = token.value;
+            self.recompute_dirty();
+        }
+    }
+}
+
+// =========================================================================
+// P4-9: Library mode types
+// =========================================================================
+
+/// Mirror of [`EditMode`] for Library-mode snippet edits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SnippetEditMode {
+    Create,
+    Update { original_name: String },
+}
+
+/// The four fields available in the Library snippet editor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnippetEditField {
+    Name,
+    Category,
+    Description,
+    Args,
+}
+
+impl SnippetEditField {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Name => Self::Category,
+            Self::Category => Self::Description,
+            Self::Description => Self::Args,
+            Self::Args => Self::Name,
+        }
+    }
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Name => Self::Args,
+            Self::Category => Self::Name,
+            Self::Description => Self::Category,
+            Self::Args => Self::Description,
+        }
+    }
+}
+
+/// In-progress user-snippet edit session (nested inside LibraryState).
+#[derive(Debug, Clone)]
+pub struct SnippetEditState {
+    pub mode: SnippetEditMode,
+    pub name: TextField,
+    pub category: crate::snippets::SnippetCategory,
+    pub description: TextField,
+    pub args: Vec<String>,
+    pub focused_field: SnippetEditField,
+    pub args_selected: usize,
+    /// When Some, the user is editing a single arg token inline.
+    pub token_edit: Option<TextField>,
+    pub dirty: bool,
+    pub exit_confirm: Option<ExitConfirm>,
+
+    initial_name: String,
+    initial_category: crate::snippets::SnippetCategory,
+    initial_description: String,
+    initial_args: Vec<String>,
+}
+
+impl SnippetEditState {
+    pub fn from_snippet(snippet: &crate::snippets::Snippet) -> Self {
+        let desc = snippet.description.clone().unwrap_or_default();
+        Self {
+            mode: SnippetEditMode::Update {
+                original_name: snippet.name.clone(),
+            },
+            name: TextField::new(&snippet.name),
+            category: snippet.category,
+            description: TextField::new(&desc),
+            args: snippet.args.clone(),
+            focused_field: SnippetEditField::Name,
+            args_selected: 0,
+            token_edit: None,
+            dirty: false,
+            exit_confirm: None,
+            initial_name: snippet.name.clone(),
+            initial_category: snippet.category,
+            initial_description: desc,
+            initial_args: snippet.args.clone(),
+        }
+    }
+
+    pub fn new_empty() -> Self {
+        Self {
+            mode: SnippetEditMode::Create,
+            name: TextField::default(),
+            category: crate::snippets::SnippetCategory::Memory,
+            description: TextField::default(),
+            args: Vec::new(),
+            focused_field: SnippetEditField::Name,
+            args_selected: 0,
+            token_edit: None,
+            dirty: false,
+            exit_confirm: None,
+            initial_name: String::new(),
+            initial_category: crate::snippets::SnippetCategory::Memory,
+            initial_description: String::new(),
+            initial_args: Vec::new(),
+        }
+    }
+
+    pub fn recompute_dirty(&mut self) {
+        self.dirty = self.name.value != self.initial_name
+            || self.category != self.initial_category
+            || self.description.value != self.initial_description
+            || self.args != self.initial_args;
+    }
+
+    pub fn category_next(&mut self) {
+        use crate::snippets::SnippetCategory::*;
+        self.category = match self.category {
+            Memory => Cpu,
+            Cpu => Machine,
+            Machine => Storage,
+            Storage => Network,
+            Network => Display,
+            Display => Debug,
+            Debug => Kernel,
+            Kernel => Memory,
+        };
+        self.recompute_dirty();
+    }
+
+    pub fn category_prev(&mut self) {
+        use crate::snippets::SnippetCategory::*;
+        self.category = match self.category {
+            Memory => Kernel,
+            Cpu => Memory,
+            Machine => Cpu,
+            Storage => Machine,
+            Network => Storage,
+            Display => Network,
+            Debug => Display,
+            Kernel => Debug,
+        };
+        self.recompute_dirty();
+    }
+
+    pub fn commit_token_edit(&mut self) {
+        if let Some(token) = self.token_edit.take()
+            && self.args_selected < self.args.len()
+        {
+            self.args[self.args_selected] = token.value;
+            self.recompute_dirty();
+        }
+    }
+}
+
+/// Pending deletion confirmation inside Library mode. `snippet_index`
+/// is the position into `SnippetsDrawerState::snippets`; `snippet_name`
+/// is denormalised here so the confirm prompt can render the name
+/// without re-looking-up the row.
+#[derive(Debug, Clone)]
+pub struct DeleteConfirm {
+    pub snippet_index: usize,
+    pub snippet_name: String,
+}
+
+/// Library mode top-level state.
+#[derive(Debug, Clone)]
+pub struct LibraryState {
+    pub snippets: SnippetsDrawerState,
+    pub edit: Option<SnippetEditState>,
+    pub delete_confirm: Option<DeleteConfirm>,
+}
+
+impl LibraryState {
+    pub fn enter() -> Self {
+        Self {
+            snippets: SnippetsDrawerState::load(),
+            edit: None,
+            delete_confirm: None,
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct App {
     pub should_quit: bool,
@@ -44,6 +593,8 @@ pub struct App {
     pub pending_launch: Option<usize>,
     pub browse_sub: BrowseSubMode,
     pub show_help: bool,
+    pub edit: Option<EditState>,
+    pub library: Option<LibraryState>,
 }
 
 impl App {
@@ -165,6 +716,45 @@ impl App {
     pub fn handle_event(&mut self, event: AppEvent) -> bool {
         if !matches!(event, AppEvent::Noop) {
             self.last_message = None;
+        }
+
+        // Edit mode gate: when an Edit session is active, only Edit-related
+        // events apply. Ctrl+C (mapped to Quit) is the universal escape
+        // hatch and discards the in-progress edit.
+        if self.edit.is_some() {
+            if matches!(event, AppEvent::Quit) {
+                self.should_quit = true;
+                self.edit = None;
+                return true;
+            }
+            if !event.is_edit_event() {
+                // Browse-only events (NavigateUp, EnterFilter, etc.) are
+                // ignored. EnterEditExisting / EnterEditNew shouldn't reach
+                // us here because translate_key only emits them when
+                // app.edit is None.
+                return true;
+            }
+        }
+
+        // Library mode gate (P4-9). Ctrl+C escape-hatches as in Edit.
+        if self.library.is_some() {
+            if matches!(event, AppEvent::Quit) {
+                self.should_quit = true;
+                self.library = None;
+                return true;
+            }
+            // Allow: library-specific events, shared drawer events, help.
+            if !event.is_library_event()
+                && !event.is_drawer_event()
+                && !matches!(event, AppEvent::ToggleHelp | AppEvent::DismissHelp)
+            {
+                return true;
+            }
+        } else if event.is_library_event() && !matches!(event, AppEvent::EnterLibrary) {
+            // Library-only event with no library active — drop silently.
+            // EnterLibrary is the one exception: it BRINGS library into
+            // existence and must be allowed through.
+            return true;
         }
 
         match event {
@@ -349,7 +939,909 @@ impl App {
                 }
                 true
             }
+            // --- Edit mode entry from Browse -------------------------------
+            AppEvent::EnterEditExisting => {
+                if let Some(ConfigEntry::Ok { config, name, .. }) = self.entries.get(self.selected)
+                {
+                    self.edit = Some(EditState::from_config(config, name));
+                } else {
+                    self.set_error("Cannot edit: select an Ok configuration first");
+                }
+                true
+            }
+            AppEvent::EnterEditNew => {
+                self.edit = Some(EditState::new_empty());
+                true
+            }
+            // --- Edit mode internals -------------------------------------
+            // P4-8: Tab and Shift+Tab swap the Editor ↔ SnippetsDrawer pane.
+            // (Field cycling moved to ↑/↓ via EditFieldUp/EditFieldDown.)
+            AppEvent::EditTab | AppEvent::EditShiftTab => {
+                if let Some(edit) = &mut self.edit {
+                    edit.focus = match edit.focus {
+                        EditFocus::Editor => EditFocus::SnippetsDrawer,
+                        EditFocus::SnippetsDrawer => EditFocus::Editor,
+                    };
+                    if edit.focus == EditFocus::Editor {
+                        // Leaving the drawer drops any half-typed filter.
+                        edit.snippets.filter.active = false;
+                        edit.snippets.filter.query = TextField::default();
+                        edit.snippets.clamp_selected();
+                    }
+                }
+                true
+            }
+            AppEvent::EditFieldUp => {
+                if let Some(edit) = &mut self.edit
+                    && edit.focus == EditFocus::Editor
+                {
+                    edit.focused_field = edit.focused_field.prev();
+                }
+                true
+            }
+            AppEvent::EditFieldDown => {
+                if let Some(edit) = &mut self.edit
+                    && edit.focus == EditFocus::Editor
+                {
+                    edit.focused_field = edit.focused_field.next();
+                }
+                true
+            }
+            AppEvent::EditTextChar(c) => {
+                if let Some(edit) = &mut self.edit {
+                    match edit.focused_field {
+                        EditField::Name => edit.name.insert_char(c),
+                        EditField::QemuBin => edit.qemu_bin.insert_char(c),
+                        EditField::Description => edit.description.insert_char(c),
+                        EditField::Args => return true,
+                    }
+                    edit.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::EditTextBackspace => {
+                if let Some(edit) = &mut self.edit {
+                    match edit.focused_field {
+                        EditField::Name => edit.name.backspace(),
+                        EditField::QemuBin => edit.qemu_bin.backspace(),
+                        EditField::Description => edit.description.backspace(),
+                        EditField::Args => return true,
+                    }
+                    edit.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::EditTextLeft => {
+                if let Some(edit) = &mut self.edit {
+                    match edit.focused_field {
+                        EditField::Name => edit.name.move_left(),
+                        EditField::QemuBin => edit.qemu_bin.move_left(),
+                        EditField::Description => edit.description.move_left(),
+                        EditField::Args => {}
+                    }
+                }
+                true
+            }
+            AppEvent::EditTextRight => {
+                if let Some(edit) = &mut self.edit {
+                    match edit.focused_field {
+                        EditField::Name => edit.name.move_right(),
+                        EditField::QemuBin => edit.qemu_bin.move_right(),
+                        EditField::Description => edit.description.move_right(),
+                        EditField::Args => {}
+                    }
+                }
+                true
+            }
+            AppEvent::EditArgsUp => {
+                if let Some(edit) = &mut self.edit
+                    && !edit.args.is_empty()
+                {
+                    edit.args_selected = edit.args_selected.saturating_sub(1);
+                }
+                true
+            }
+            AppEvent::EditArgsDown => {
+                if let Some(edit) = &mut self.edit
+                    && !edit.args.is_empty()
+                {
+                    edit.args_selected = (edit.args_selected + 1).min(edit.args.len() - 1);
+                }
+                true
+            }
+            AppEvent::EditArgsMoveUp => {
+                if let Some(edit) = &mut self.edit
+                    && !edit.args.is_empty()
+                    && edit.args_selected > 0
+                {
+                    edit.args.swap(edit.args_selected, edit.args_selected - 1);
+                    edit.args_selected -= 1;
+                    edit.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::EditArgsMoveDown => {
+                if let Some(edit) = &mut self.edit
+                    && !edit.args.is_empty()
+                    && edit.args_selected + 1 < edit.args.len()
+                {
+                    edit.args.swap(edit.args_selected, edit.args_selected + 1);
+                    edit.args_selected += 1;
+                    edit.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::EditArgsDelete => {
+                if let Some(edit) = &mut self.edit
+                    && !edit.args.is_empty()
+                {
+                    edit.args.remove(edit.args_selected);
+                    if edit.args.is_empty() {
+                        edit.args_selected = 0;
+                    } else if edit.args_selected >= edit.args.len() {
+                        edit.args_selected = edit.args.len() - 1;
+                    }
+                    edit.recompute_dirty();
+                }
+                true
+            }
+            // P4-10: args token editing -----------------------------------
+            AppEvent::EditArgsAddEmpty => {
+                if let Some(edit) = &mut self.edit
+                    && edit.focus == EditFocus::Editor
+                    && edit.focused_field == EditField::Args
+                {
+                    let insert_at = if edit.args.is_empty() {
+                        0
+                    } else {
+                        edit.args_selected + 1
+                    };
+                    edit.args.insert(insert_at, String::new());
+                    edit.args_selected = insert_at;
+                    edit.token_edit = Some(TextField::default());
+                    edit.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::EditArgsEnterToken => {
+                if let Some(edit) = &mut self.edit
+                    && edit.args_selected < edit.args.len()
+                {
+                    let current = edit.args[edit.args_selected].clone();
+                    edit.token_edit = Some(TextField::new(&current));
+                }
+                true
+            }
+            AppEvent::EditTokenChar(c) => {
+                if let Some(edit) = &mut self.edit
+                    && let Some(field) = &mut edit.token_edit
+                {
+                    field.insert_char(c);
+                }
+                true
+            }
+            AppEvent::EditTokenBackspace => {
+                if let Some(edit) = &mut self.edit
+                    && let Some(field) = &mut edit.token_edit
+                {
+                    field.backspace();
+                }
+                true
+            }
+            AppEvent::EditTokenLeft => {
+                if let Some(edit) = &mut self.edit
+                    && let Some(field) = &mut edit.token_edit
+                {
+                    field.move_left();
+                }
+                true
+            }
+            AppEvent::EditTokenRight => {
+                if let Some(edit) = &mut self.edit
+                    && let Some(field) = &mut edit.token_edit
+                {
+                    field.move_right();
+                }
+                true
+            }
+            AppEvent::EditTokenCommit => {
+                if let Some(edit) = &mut self.edit {
+                    edit.commit_token_edit();
+                }
+                true
+            }
+            AppEvent::EditSave => {
+                self.try_save_edit();
+                true
+            }
+            AppEvent::EditCancel => {
+                if let Some(edit) = &mut self.edit {
+                    if edit.dirty {
+                        edit.exit_confirm = Some(ExitConfirm::Pending);
+                    } else {
+                        self.edit = None;
+                    }
+                }
+                true
+            }
+            AppEvent::EditConfirmSave => {
+                if let Some(edit) = &mut self.edit {
+                    edit.exit_confirm = None;
+                }
+                self.try_save_edit();
+                true
+            }
+            AppEvent::EditConfirmDiscard => {
+                self.edit = None;
+                true
+            }
+            AppEvent::EditConfirmCancel => {
+                if let Some(edit) = &mut self.edit {
+                    edit.exit_confirm = None;
+                }
+                true
+            }
+            // --- Snippets drawer (shared between Edit mode + Library mode) ---
+            AppEvent::SnippetsDrawerUp => {
+                if let Some(d) = self.active_drawer_mut() {
+                    d.selected = d.selected.saturating_sub(1);
+                }
+                true
+            }
+            AppEvent::SnippetsDrawerDown => {
+                if let Some(d) = self.active_drawer_mut() {
+                    let len = d.visible_rows().len();
+                    if len > 0 && d.selected + 1 < len {
+                        d.selected += 1;
+                    }
+                }
+                true
+            }
+            AppEvent::SnippetsDrawerToggleCollapse => {
+                if let Some(d) = self.active_drawer_mut() {
+                    let cat_to_toggle = match d.current_row() {
+                        Some(DrawerRow::CategoryHeader { category, .. }) => Some(category),
+                        Some(DrawerRow::Snippet { snippet_index }) => {
+                            d.snippets.get(snippet_index).map(|s| s.category)
+                        }
+                        None => None,
+                    };
+                    if let Some(cat) = cat_to_toggle {
+                        d.toggle_collapse(cat);
+                        let rows = d.visible_rows();
+                        if let Some(idx) = rows.iter().position(|r| {
+                            matches!(r, DrawerRow::CategoryHeader { category, .. } if *category == cat)
+                        }) {
+                            d.selected = idx;
+                        } else {
+                            d.clamp_selected();
+                        }
+                    }
+                }
+                true
+            }
+            AppEvent::SnippetsDrawerEnterFilter => {
+                if let Some(d) = self.active_drawer_mut() {
+                    d.filter.active = true;
+                }
+                true
+            }
+            AppEvent::SnippetsDrawerExitFilter => {
+                if let Some(d) = self.active_drawer_mut() {
+                    d.filter.active = false;
+                    d.filter.query = TextField::default();
+                    d.clamp_selected();
+                }
+                true
+            }
+            AppEvent::SnippetsDrawerFilterChar(c) => {
+                if let Some(d) = self.active_drawer_mut() {
+                    d.filter.query.insert_char(c);
+                    d.clamp_selected();
+                }
+                true
+            }
+            AppEvent::SnippetsDrawerFilterBackspace => {
+                if let Some(d) = self.active_drawer_mut() {
+                    d.filter.query.backspace();
+                    d.clamp_selected();
+                }
+                true
+            }
+            AppEvent::SnippetsDrawerInsert => {
+                let to_insert: Option<crate::snippets::Snippet> =
+                    self.edit
+                        .as_ref()
+                        .and_then(|edit| match edit.snippets.current_row()? {
+                            DrawerRow::Snippet { snippet_index } => {
+                                edit.snippets.snippets.get(snippet_index).cloned()
+                            }
+                            DrawerRow::CategoryHeader { .. } => None,
+                        });
+                if let Some(snippet) = to_insert {
+                    if let Some(edit) = &mut self.edit {
+                        let insert_at = if edit.args.is_empty() {
+                            0
+                        } else {
+                            edit.args_selected + 1
+                        };
+                        for (offset, token) in snippet.args.iter().enumerate() {
+                            edit.args.insert(insert_at + offset, token.clone());
+                        }
+                        if !snippet.args.is_empty() {
+                            edit.args_selected = insert_at + snippet.args.len() - 1;
+                        }
+                        edit.recompute_dirty();
+                    }
+                    self.set_info(format!("Inserted snippet '{}'", snippet.name));
+                }
+                true
+            }
+            // --- P4-9: Library mode entry / exit ----------------------
+            AppEvent::EnterLibrary => {
+                self.library = Some(LibraryState::enter());
+                true
+            }
+            AppEvent::ExitLibrary => {
+                self.library = None;
+                true
+            }
+            // --- P4-9: Library CRUD triggers --------------------------
+            AppEvent::LibraryNew => {
+                if let Some(lib) = &mut self.library {
+                    lib.edit = Some(SnippetEditState::new_empty());
+                }
+                true
+            }
+            AppEvent::LibraryEditSelected => {
+                let target: Option<(crate::snippets::Snippet, bool)> = self
+                    .library
+                    .as_ref()
+                    .and_then(|lib| match lib.snippets.current_row()? {
+                        DrawerRow::Snippet { snippet_index } => {
+                            let s = lib.snippets.snippets.get(snippet_index)?.clone();
+                            let is_builtin = is_builtin_snippet_name(&s.name);
+                            Some((s, is_builtin))
+                        }
+                        DrawerRow::CategoryHeader { .. } => None,
+                    });
+                match target {
+                    Some((_, true)) => {
+                        self.set_error(
+                            "'e' and 'd' are disabled for builtin snippets. \
+                             Press 'n' to create your own.",
+                        );
+                    }
+                    Some((snippet, false)) => {
+                        if let Some(lib) = &mut self.library {
+                            lib.edit = Some(SnippetEditState::from_snippet(&snippet));
+                        }
+                    }
+                    None => {}
+                }
+                true
+            }
+            AppEvent::LibraryDeleteSelected => {
+                let target: Option<(usize, String, bool)> =
+                    self.library
+                        .as_ref()
+                        .and_then(|lib| match lib.snippets.current_row()? {
+                            DrawerRow::Snippet { snippet_index } => {
+                                let s = lib.snippets.snippets.get(snippet_index)?.clone();
+                                let is_builtin = is_builtin_snippet_name(&s.name);
+                                Some((snippet_index, s.name, is_builtin))
+                            }
+                            DrawerRow::CategoryHeader { .. } => None,
+                        });
+                match target {
+                    Some((_, _, true)) => {
+                        self.set_error(
+                            "'e' and 'd' are disabled for builtin snippets. \
+                             Press 'n' to create your own.",
+                        );
+                    }
+                    Some((idx, name, false)) => {
+                        if let Some(lib) = &mut self.library {
+                            lib.delete_confirm = Some(DeleteConfirm {
+                                snippet_index: idx,
+                                snippet_name: name,
+                            });
+                        }
+                    }
+                    None => {}
+                }
+                true
+            }
+            AppEvent::LibraryDeleteConfirm => {
+                let to_remove: Option<String> = self
+                    .library
+                    .as_mut()
+                    .and_then(|lib| lib.delete_confirm.take().map(|c| c.snippet_name));
+                if let Some(name) = to_remove {
+                    let user_only: Vec<crate::snippets::Snippet> = self
+                        .library
+                        .as_ref()
+                        .map(|lib| {
+                            lib.snippets
+                                .snippets
+                                .iter()
+                                .filter(|s| s.name != name && !is_builtin_snippet_name(&s.name))
+                                .cloned()
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    match crate::snippets::save_user_snippets(&user_only) {
+                        Ok(()) => {
+                            if let Some(lib) = &mut self.library {
+                                lib.snippets = SnippetsDrawerState::load();
+                            }
+                            self.set_info(format!("Deleted '{}'", name));
+                        }
+                        Err(e) => {
+                            self.set_error(format!("Failed to write snippets.json: {}", e));
+                        }
+                    }
+                }
+                true
+            }
+            AppEvent::LibraryDeleteCancel => {
+                if let Some(lib) = &mut self.library {
+                    lib.delete_confirm = None;
+                }
+                true
+            }
+            // --- P4-9: SnippetEdit handlers ---------------------------
+            AppEvent::SnippetEditFieldUp => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.focused_field = s.focused_field.prev();
+                }
+                true
+            }
+            AppEvent::SnippetEditFieldDown => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.focused_field = s.focused_field.next();
+                }
+                true
+            }
+            AppEvent::SnippetEditTextChar(c) => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    match s.focused_field {
+                        SnippetEditField::Name => s.name.insert_char(c),
+                        SnippetEditField::Description => s.description.insert_char(c),
+                        _ => return true,
+                    }
+                    s.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::SnippetEditTextBackspace => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    match s.focused_field {
+                        SnippetEditField::Name => s.name.backspace(),
+                        SnippetEditField::Description => s.description.backspace(),
+                        _ => return true,
+                    }
+                    s.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::SnippetEditTextLeft => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    match s.focused_field {
+                        SnippetEditField::Name => s.name.move_left(),
+                        SnippetEditField::Description => s.description.move_left(),
+                        _ => {}
+                    }
+                }
+                true
+            }
+            AppEvent::SnippetEditTextRight => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    match s.focused_field {
+                        SnippetEditField::Name => s.name.move_right(),
+                        SnippetEditField::Description => s.description.move_right(),
+                        _ => {}
+                    }
+                }
+                true
+            }
+            AppEvent::SnippetEditCategoryPrev => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.category_prev();
+                }
+                true
+            }
+            AppEvent::SnippetEditCategoryNext => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.category_next();
+                }
+                true
+            }
+            AppEvent::SnippetEditArgsUp => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && !s.args.is_empty()
+                {
+                    s.args_selected = s.args_selected.saturating_sub(1);
+                }
+                true
+            }
+            AppEvent::SnippetEditArgsDown => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && !s.args.is_empty()
+                {
+                    s.args_selected = (s.args_selected + 1).min(s.args.len() - 1);
+                }
+                true
+            }
+            AppEvent::SnippetEditArgsMoveUp => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && !s.args.is_empty()
+                    && s.args_selected > 0
+                {
+                    s.args.swap(s.args_selected, s.args_selected - 1);
+                    s.args_selected -= 1;
+                    s.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::SnippetEditArgsMoveDown => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && !s.args.is_empty()
+                    && s.args_selected + 1 < s.args.len()
+                {
+                    s.args.swap(s.args_selected, s.args_selected + 1);
+                    s.args_selected += 1;
+                    s.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::SnippetEditArgsDelete => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && !s.args.is_empty()
+                {
+                    s.args.remove(s.args_selected);
+                    if s.args.is_empty() {
+                        s.args_selected = 0;
+                    } else if s.args_selected >= s.args.len() {
+                        s.args_selected = s.args.len() - 1;
+                    }
+                    s.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::SnippetEditArgsAddEmpty => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    let insert_at = if s.args.is_empty() {
+                        0
+                    } else {
+                        s.args_selected + 1
+                    };
+                    s.args.insert(insert_at, String::new());
+                    s.args_selected = insert_at;
+                    s.token_edit = Some(TextField::default());
+                    s.recompute_dirty();
+                }
+                true
+            }
+            AppEvent::SnippetEditArgsEnterToken => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && s.args_selected < s.args.len()
+                {
+                    let current = s.args[s.args_selected].clone();
+                    s.token_edit = Some(TextField::new(&current));
+                }
+                true
+            }
+            AppEvent::SnippetEditTokenChar(c) => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && let Some(field) = &mut s.token_edit
+                {
+                    field.insert_char(c);
+                }
+                true
+            }
+            AppEvent::SnippetEditTokenBackspace => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && let Some(field) = &mut s.token_edit
+                {
+                    field.backspace();
+                }
+                true
+            }
+            AppEvent::SnippetEditTokenLeft => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && let Some(field) = &mut s.token_edit
+                {
+                    field.move_left();
+                }
+                true
+            }
+            AppEvent::SnippetEditTokenRight => {
+                if let Some(s) = self.active_snippet_edit_mut()
+                    && let Some(field) = &mut s.token_edit
+                {
+                    field.move_right();
+                }
+                true
+            }
+            AppEvent::SnippetEditTokenCommit => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.commit_token_edit();
+                }
+                true
+            }
+            AppEvent::SnippetEditSave => {
+                self.try_save_snippet_edit();
+                true
+            }
+            AppEvent::SnippetEditCancel => {
+                let should_confirm = self
+                    .active_snippet_edit_mut()
+                    .map(|s| s.dirty)
+                    .unwrap_or(false);
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    if should_confirm {
+                        s.exit_confirm = Some(ExitConfirm::Pending);
+                    } else if let Some(lib) = &mut self.library {
+                        lib.edit = None;
+                    }
+                }
+                true
+            }
+            AppEvent::SnippetEditConfirmSave => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.exit_confirm = None;
+                }
+                self.try_save_snippet_edit();
+                true
+            }
+            AppEvent::SnippetEditConfirmDiscard => {
+                if let Some(lib) = &mut self.library {
+                    lib.edit = None;
+                }
+                true
+            }
+            AppEvent::SnippetEditConfirmCancel => {
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.exit_confirm = None;
+                }
+                true
+            }
             AppEvent::Noop => false,
         }
     }
+
+    // --- P4-9: helpers ---------------------------------------------------
+
+    /// Returns the active drawer state (Library mode first, then Edit mode).
+    /// `app.library` and `app.edit` are mutually exclusive, so at most one
+    /// branch is reachable.
+    fn active_drawer_mut(&mut self) -> Option<&mut SnippetsDrawerState> {
+        if let Some(lib) = &mut self.library {
+            return Some(&mut lib.snippets);
+        }
+        if let Some(edit) = &mut self.edit {
+            return Some(&mut edit.snippets);
+        }
+        None
+    }
+
+    fn active_snippet_edit_mut(&mut self) -> Option<&mut SnippetEditState> {
+        self.library.as_mut()?.edit.as_mut()
+    }
+
+    /// Try to save the in-progress SnippetEditState. Writes to disk and
+    /// reloads the drawer on success; leaves edit open with an error
+    /// message on failure.
+    fn try_save_snippet_edit(&mut self) {
+        type SaveSnapshot = (
+            String,
+            crate::snippets::SnippetCategory,
+            Option<String>,
+            Vec<String>,
+            SnippetEditMode,
+        );
+        let snapshot: Option<SaveSnapshot> = self.library.as_ref().and_then(|lib| {
+            lib.edit.as_ref().map(|s| {
+                (
+                    s.name.value.trim().to_string(),
+                    s.category,
+                    if s.description.value.trim().is_empty() {
+                        None
+                    } else {
+                        Some(s.description.value.trim().to_string())
+                    },
+                    s.args.iter().filter(|a| !a.is_empty()).cloned().collect(),
+                    s.mode.clone(),
+                )
+            })
+        });
+        let Some((name, category, desc, args, mode)) = snapshot else {
+            return;
+        };
+
+        if name.is_empty() {
+            self.set_error("Snippet name cannot be empty");
+            return;
+        }
+        // Check builtin collision FIRST — it's a more specific error than
+        // "invalid name characters" for users who typed a builtin name
+        // verbatim (e.g. "1G memory" — has a space, also a builtin).
+        if is_builtin_snippet_name(&name) {
+            self.set_error(format!(
+                "Cannot use builtin name '{}'. Choose a different name.",
+                name
+            ));
+            return;
+        }
+        if let Err(e) = crate::config::validate_config_name(&name) {
+            self.set_error(format!("Invalid name: {}", e));
+            return;
+        }
+
+        // Build the new user-only list.
+        let current: Vec<crate::snippets::Snippet> = self
+            .library
+            .as_ref()
+            .map(|lib| lib.snippets.snippets.clone())
+            .unwrap_or_default();
+        let mut user_only: Vec<crate::snippets::Snippet> = current
+            .iter()
+            .filter(|s| !is_builtin_snippet_name(&s.name))
+            .cloned()
+            .collect();
+
+        let new_snippet = crate::snippets::Snippet {
+            name: name.clone(),
+            args,
+            category,
+            description: desc,
+        };
+        match &mode {
+            SnippetEditMode::Create => {
+                if user_only.iter().any(|s| s.name == name) {
+                    self.set_error(format!("Snippet '{}' already exists", name));
+                    return;
+                }
+                user_only.push(new_snippet);
+            }
+            SnippetEditMode::Update { original_name } => {
+                if name != *original_name && user_only.iter().any(|s| s.name == name) {
+                    self.set_error(format!("Snippet '{}' already exists", name));
+                    return;
+                }
+                if let Some(pos) = user_only.iter().position(|s| s.name == *original_name) {
+                    user_only[pos] = new_snippet;
+                } else {
+                    user_only.push(new_snippet);
+                }
+            }
+        }
+
+        match crate::snippets::save_user_snippets(&user_only) {
+            Ok(()) => {
+                if let Some(lib) = &mut self.library {
+                    lib.edit = None;
+                    lib.snippets = SnippetsDrawerState::load();
+                    let rows = lib.snippets.visible_rows();
+                    let target_idx = rows.iter().position(|r| {
+                        matches!(r, DrawerRow::Snippet { snippet_index }
+                            if lib.snippets.snippets[*snippet_index].name == name)
+                    });
+                    if let Some(idx) = target_idx {
+                        lib.snippets.selected = idx;
+                    }
+                }
+                self.set_info(format!("Saved snippet '{}'", name));
+            }
+            Err(e) => {
+                self.set_error(format!("Failed to write snippets.json: {}", e));
+            }
+        }
+    }
+
+    /// Save the in-progress edit. On success: clear `self.edit`, rescan
+    /// configs, select the saved entry, and set an info message. On
+    /// failure: leave `self.edit` open and set an error message.
+    fn try_save_edit(&mut self) {
+        let Some(edit) = &self.edit else { return };
+
+        let name = edit.name.value.trim().to_string();
+        if let Err(e) = crate::config::validate_config_name(&name) {
+            self.set_error(format!("Invalid name: {}", e));
+            return;
+        }
+
+        let qemu_bin = edit.qemu_bin.value.trim().to_string();
+        let description = if edit.description.value.trim().is_empty() {
+            None
+        } else {
+            Some(edit.description.value.trim().to_string())
+        };
+        let config = QemuConfig {
+            qemu_bin,
+            args: edit.args.clone(),
+            desc: description,
+            qemu_version: edit.preserved_qemu_version.clone(),
+            resources: edit.preserved_resources.clone(),
+        };
+
+        if let Err(e) = crate::config::validate_config(&config) {
+            self.set_error(format!("Invalid config: {}", e));
+            return;
+        }
+
+        let config_dir = match crate::config::config_dir() {
+            Ok(p) => p,
+            Err(e) => {
+                self.set_error(format!("Cannot resolve config dir: {}", e));
+                return;
+            }
+        };
+        let new_path = config_dir.join(format!("{}.json", name));
+
+        match &edit.mode {
+            EditMode::Create => {
+                if new_path.exists() {
+                    self.set_error(format!("Config '{}' already exists", name));
+                    return;
+                }
+            }
+            EditMode::Update { original_name } => {
+                if name != *original_name {
+                    if new_path.exists() {
+                        self.set_error(format!("Config '{}' already exists", name));
+                        return;
+                    }
+                    let old_path = config_dir.join(format!("{}.json", original_name));
+                    if let Err(e) = std::fs::remove_file(&old_path) {
+                        self.set_error(format!("Failed to remove old config: {}", e));
+                        return;
+                    }
+                }
+            }
+        }
+
+        let json = match serde_json::to_string_pretty(&config) {
+            Ok(s) => s,
+            Err(e) => {
+                self.set_error(format!("Failed to serialize: {}", e));
+                return;
+            }
+        };
+        if let Err(e) = std::fs::write(&new_path, json) {
+            self.set_error(format!("Failed to write config: {}", e));
+            return;
+        }
+
+        let entry_name = name.clone();
+        self.edit = None;
+
+        match scan::scan_configs() {
+            Ok(new_entries) => {
+                self.entries = new_entries;
+                self.selected = self
+                    .entries
+                    .iter()
+                    .position(|e| e.name() == entry_name)
+                    .unwrap_or(0);
+            }
+            Err(e) => {
+                self.set_error(format!("Saved but rescan failed: {}", e));
+                return;
+            }
+        }
+
+        self.right_scroll = 0;
+        self.set_info(format!("Saved '{}'", entry_name));
+    }
+}
+
+/// Returns true if the given name matches a built-in snippet. P4-9 uses
+/// this to gate edit/delete operations and to filter the user-only set
+/// before persistence.
+pub(crate) fn is_builtin_snippet_name(name: &str) -> bool {
+    crate::snippets::builtin_snippets()
+        .iter()
+        .any(|s| s.name == name)
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1366,27 +1366,40 @@ impl App {
                     .as_mut()
                     .and_then(|lib| lib.delete_confirm.take().map(|c| c.snippet_name));
                 if let Some(name) = to_remove {
-                    let user_only: Vec<crate::snippets::Snippet> = self
+                    let mut user_only: Vec<crate::snippets::Snippet> = self
                         .library
                         .as_ref()
-                        .map(|lib| {
-                            lib.snippets
-                                .snippets
-                                .iter()
-                                .filter(|s| s.name != name && !is_builtin_snippet_name(&s.name))
-                                .cloned()
-                                .collect()
-                        })
+                        .map(|lib| lib.user_only.clone())
                         .unwrap_or_default();
-                    match crate::snippets::save_user_snippets(&user_only) {
-                        Ok(()) => {
-                            if let Some(lib) = &mut self.library {
-                                lib.snippets = SnippetsDrawerState::load();
+                    let pos = user_only.iter().position(|s| s.name == name);
+                    match pos {
+                        Some(idx) => {
+                            user_only.remove(idx);
+                            match crate::snippets::save_user_snippets(&user_only) {
+                                Ok(()) => {
+                                    if let Some(lib) = &mut self.library {
+                                        lib.user_only = user_only;
+                                        lib.snippets = SnippetsDrawerState::load();
+                                    }
+                                    self.set_info(format!("Deleted '{}'", name));
+                                }
+                                Err(e) => {
+                                    self.set_error(format!(
+                                        "Failed to write snippets.json: {}",
+                                        e
+                                    ));
+                                }
                             }
-                            self.set_info(format!("Deleted '{}'", name));
                         }
-                        Err(e) => {
-                            self.set_error(format!("Failed to write snippets.json: {}", e));
+                        None => {
+                            // Defensive: LibraryDeleteSelected already blocks
+                            // pure builtins before delete_confirm is set, so
+                            // this branch should be unreachable. Refuse the
+                            // operation rather than panic if the invariant
+                            // ever breaks.
+                            self.set_error(
+                                "Cannot delete built-in snippet; create an override to customize.",
+                            );
                         }
                     }
                 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1320,8 +1320,7 @@ impl App {
                     .and_then(|lib| match lib.snippets.current_row()? {
                         DrawerRow::Snippet { snippet_index } => {
                             let s = lib.snippets.snippets.get(snippet_index)?.clone();
-                            let is_pure_builtin =
-                                !lib.user_only.iter().any(|u| u.name == s.name);
+                            let is_pure_builtin = !lib.user_only.iter().any(|u| u.name == s.name);
                             Some((s, is_pure_builtin))
                         }
                         DrawerRow::CategoryHeader { .. } => None,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1307,14 +1307,22 @@ impl App {
                 true
             }
             AppEvent::LibraryEditSelected => {
+                // A merged row is "manageable" when an entry with the same name
+                // exists in user_only — i.e. it is either a pure user snippet
+                // or an override of a builtin. Pure builtins (no override yet)
+                // are blocked so the user is nudged to create an override
+                // explicitly. Classifying by name vs. the builtin set is wrong
+                // because it would also block overrides whose name collides
+                // with a builtin.
                 let target: Option<(crate::snippets::Snippet, bool)> = self
                     .library
                     .as_ref()
                     .and_then(|lib| match lib.snippets.current_row()? {
                         DrawerRow::Snippet { snippet_index } => {
                             let s = lib.snippets.snippets.get(snippet_index)?.clone();
-                            let is_builtin = is_builtin_snippet_name(&s.name);
-                            Some((s, is_builtin))
+                            let is_pure_builtin =
+                                !lib.user_only.iter().any(|u| u.name == s.name);
+                            Some((s, is_pure_builtin))
                         }
                         DrawerRow::CategoryHeader { .. } => None,
                     });
@@ -1341,8 +1349,9 @@ impl App {
                         .and_then(|lib| match lib.snippets.current_row()? {
                             DrawerRow::Snippet { snippet_index } => {
                                 let s = lib.snippets.snippets.get(snippet_index)?.clone();
-                                let is_builtin = is_builtin_snippet_name(&s.name);
-                                Some((snippet_index, s.name, is_builtin))
+                                let is_pure_builtin =
+                                    !lib.user_only.iter().any(|u| u.name == s.name);
+                                Some((snippet_index, s.name, is_pure_builtin))
                             }
                             DrawerRow::CategoryHeader { .. } => None,
                         });

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -570,14 +570,22 @@ pub struct LibraryState {
     pub snippets: SnippetsDrawerState,
     pub edit: Option<SnippetEditState>,
     pub delete_confirm: Option<DeleteConfirm>,
+    /// Snapshot of the on-disk user snippets list. The persistence baseline
+    /// for save/delete: we mutate this in place and write it back, instead
+    /// of reconstructing the user list by filtering merged snippets through
+    /// `is_builtin_snippet_name` (which would drop any user override whose
+    /// name collides with a builtin).
+    pub user_only: Vec<crate::snippets::Snippet>,
 }
 
 impl LibraryState {
     pub fn enter() -> Self {
+        let user_only = crate::snippets::load_user_snippets().unwrap_or_default();
         Self {
             snippets: SnippetsDrawerState::load(),
             edit: None,
             delete_confirm: None,
+            user_only,
         }
     }
 }
@@ -1679,17 +1687,16 @@ impl App {
             return;
         }
 
-        // Build the new user-only list.
-        let current: Vec<crate::snippets::Snippet> = self
+        // Mutate the on-disk user list snapshot. Looking up entries by the
+        // pre-edit name (original_name) is what lets renames work and is
+        // also what makes overrides whose name collides with a builtin
+        // survive a save — previously we filtered merged snippets through
+        // is_builtin_snippet_name and silently dropped them.
+        let mut user_only: Vec<crate::snippets::Snippet> = self
             .library
             .as_ref()
-            .map(|lib| lib.snippets.snippets.clone())
+            .map(|lib| lib.user_only.clone())
             .unwrap_or_default();
-        let mut user_only: Vec<crate::snippets::Snippet> = current
-            .iter()
-            .filter(|s| !is_builtin_snippet_name(&s.name))
-            .cloned()
-            .collect();
 
         let new_snippet = crate::snippets::Snippet {
             name: name.clone(),
@@ -1713,6 +1720,8 @@ impl App {
                 if let Some(pos) = user_only.iter().position(|s| s.name == *original_name) {
                     user_only[pos] = new_snippet;
                 } else {
+                    // Editing a builtin without an existing override creates
+                    // one — append it.
                     user_only.push(new_snippet);
                 }
             }
@@ -1721,6 +1730,7 @@ impl App {
         match crate::snippets::save_user_snippets(&user_only) {
             Ok(()) => {
                 if let Some(lib) = &mut self.library {
+                    lib.user_only = user_only;
                     lib.edit = None;
                     lib.snippets = SnippetsDrawerState::load();
                     let rows = lib.snippets.visible_rows();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1796,7 +1796,12 @@ impl App {
         // Mirror snippet-save's strip rule (is_empty, not trim().is_empty)
         // so an Args-list row left empty via EditArgsAddEmpty doesn't end
         // up in the saved JSON as a "" token that would break launch.
-        let args: Vec<String> = edit.args.iter().filter(|a| !a.is_empty()).cloned().collect();
+        let args: Vec<String> = edit
+            .args
+            .iter()
+            .filter(|a| !a.is_empty())
+            .cloned()
+            .collect();
         let config = QemuConfig {
             qemu_bin,
             args,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -319,6 +319,11 @@ pub struct EditState {
     pub focus: EditFocus,
     /// Snippets drawer state.
     pub snippets: SnippetsDrawerState,
+    /// Snapshot of the on-disk user snippets list, used by render to
+    /// classify drawer rows as `[user]` vs `[builtin]` by membership
+    /// rather than by name (so overrides whose name collides with a
+    /// builtin still render as user-owned).
+    pub user_only_snippets: Vec<crate::snippets::Snippet>,
     /// When `Some`, the currently-selected arg in the Args field is being
     /// edited in place via a TextField overlay. Set by `EditArgsAddEmpty`
     /// or `EditArgsEnterToken`; committed back to `args[args_selected]`
@@ -353,6 +358,7 @@ impl EditState {
             exit_confirm: None,
             focus: EditFocus::Editor,
             snippets: SnippetsDrawerState::load(),
+            user_only_snippets: crate::snippets::load_user_snippets().unwrap_or_default(),
             token_edit: None,
             preserved_resources: config.resources.clone(),
             preserved_qemu_version: config.qemu_version.clone(),
@@ -376,6 +382,7 @@ impl EditState {
             exit_confirm: None,
             focus: EditFocus::Editor,
             snippets: SnippetsDrawerState::load(),
+            user_only_snippets: crate::snippets::load_user_snippets().unwrap_or_default(),
             token_edit: None,
             preserved_resources: std::collections::HashMap::new(),
             preserved_qemu_version: None,
@@ -1867,11 +1874,3 @@ impl App {
     }
 }
 
-/// Returns true if the given name matches a built-in snippet. P4-9 uses
-/// this to gate edit/delete operations and to filter the user-only set
-/// before persistence.
-pub(crate) fn is_builtin_snippet_name(name: &str) -> bool {
-    crate::snippets::builtin_snippets()
-        .iter()
-        .any(|s| s.name == name)
-}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1159,6 +1159,11 @@ impl App {
                 true
             }
             AppEvent::EditSave => {
+                // Commit any in-progress token edit so Ctrl+S from inside the
+                // token-edit overlay does not silently drop the buffered text.
+                if let Some(edit) = &mut self.edit {
+                    edit.commit_token_edit();
+                }
                 self.try_save_edit();
                 true
             }
@@ -1589,6 +1594,11 @@ impl App {
                 true
             }
             AppEvent::SnippetEditSave => {
+                // Commit any in-progress token edit so Ctrl+S from inside the
+                // token-edit overlay does not silently drop the buffered text.
+                if let Some(s) = self.active_snippet_edit_mut() {
+                    s.commit_token_edit();
+                }
                 self.try_save_snippet_edit();
                 true
             }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1700,7 +1700,7 @@ impl App {
             self.set_error("Snippet name cannot be empty");
             return;
         }
-        if let Err(e) = crate::config::validate_config_name(&name) {
+        if let Err(e) = crate::snippets::validate_snippet_name(&name) {
             self.set_error(format!("Invalid name: {}", e));
             return;
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1788,16 +1788,9 @@ impl App {
                 }
             }
             EditMode::Update { original_name } => {
-                if name != *original_name {
-                    if new_path.exists() {
-                        self.set_error(format!("Config '{}' already exists", name));
-                        return;
-                    }
-                    let old_path = config_dir.join(format!("{}.json", original_name));
-                    if let Err(e) = std::fs::remove_file(&old_path) {
-                        self.set_error(format!("Failed to remove old config: {}", e));
-                        return;
-                    }
+                if name != *original_name && new_path.exists() {
+                    self.set_error(format!("Config '{}' already exists", name));
+                    return;
                 }
             }
         }
@@ -1812,6 +1805,18 @@ impl App {
         if let Err(e) = std::fs::write(&new_path, json) {
             self.set_error(format!("Failed to write config: {}", e));
             return;
+        }
+        if let EditMode::Update { original_name } = &edit.mode {
+            if name != *original_name {
+                let old_path = config_dir.join(format!("{}.json", original_name));
+                if let Err(e) = std::fs::remove_file(&old_path) {
+                    self.set_error(format!(
+                        "Saved new config but failed to remove old: {}",
+                        e
+                    ));
+                    return;
+                }
+            }
         }
 
         let entry_name = name.clone();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -583,16 +583,26 @@ pub struct LibraryState {
     /// `is_builtin_snippet_name` (which would drop any user override whose
     /// name collides with a builtin).
     pub user_only: Vec<crate::snippets::Snippet>,
+    /// `Some(msg)` when load_user_snippets failed at enter() with a real
+    /// error (file exists but is corrupt JSON or IO-broken; a missing file
+    /// is not an error). When set, every Library write path is blocked at
+    /// its handler entry — we must NOT write an empty `user_only` baseline
+    /// over the user's on-disk data while the file is unreadable.
+    pub load_error: Option<String>,
 }
 
 impl LibraryState {
     pub fn enter() -> Self {
-        let user_only = crate::snippets::load_user_snippets().unwrap_or_default();
+        let (user_only, load_error) = match crate::snippets::load_user_snippets() {
+            Ok(v) => (v, None),
+            Err(e) => (Vec::new(), Some(format!("{}", e))),
+        };
         Self {
             snippets: SnippetsDrawerState::load(),
             edit: None,
             delete_confirm: None,
             user_only,
+            load_error,
         }
     }
 }
@@ -1299,7 +1309,16 @@ impl App {
             }
             // --- P4-9: Library mode entry / exit ----------------------
             AppEvent::EnterLibrary => {
-                self.library = Some(LibraryState::enter());
+                let state = LibraryState::enter();
+                let load_err = state.load_error.clone();
+                self.library = Some(state);
+                if let Some(err) = load_err {
+                    self.set_error(format!(
+                        "Library is read-only: snippets.json failed to load ({}). \
+                         Fix or remove the file, then reopen.",
+                        err
+                    ));
+                }
                 true
             }
             AppEvent::ExitLibrary => {
@@ -1381,6 +1400,21 @@ impl App {
                 true
             }
             AppEvent::LibraryDeleteConfirm => {
+                // Read-only guard: if snippets.json failed to load at enter(),
+                // user_only is an empty baseline that does NOT reflect disk.
+                // Writing it back would destroy the user's data. Clear the
+                // confirm modal so the UI escapes, but never call save.
+                if let Some(lib) = &mut self.library
+                    && let Some(err) = lib.load_error.clone()
+                {
+                    lib.delete_confirm = None;
+                    self.set_error(format!(
+                        "Cannot delete: snippets.json failed to load ({}). \
+                         Fix or remove the file, then reopen.",
+                        err
+                    ));
+                    return true;
+                }
                 let to_remove: Option<String> = self
                     .library
                     .as_mut()
@@ -1677,6 +1711,21 @@ impl App {
     /// reloads the drawer on success; leaves edit open with an error
     /// message on failure.
     fn try_save_snippet_edit(&mut self) {
+        // Read-only guard: same reasoning as LibraryDeleteConfirm. Leave the
+        // edit overlay open so the user keeps their typing — only the disk
+        // write is refused.
+        if let Some(err) = self
+            .library
+            .as_ref()
+            .and_then(|lib| lib.load_error.clone())
+        {
+            self.set_error(format!(
+                "Cannot save: snippets.json failed to load ({}). \
+                 Fix or remove the file, then reopen.",
+                err
+            ));
+            return;
+        }
         type SaveSnapshot = (
             String,
             crate::snippets::SnippetCategory,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1866,6 +1866,14 @@ impl App {
                     .iter()
                     .position(|e| e.name() == entry_name)
                     .unwrap_or(0);
+                // Mirror the Refresh handler: when a filter is active, the
+                // saved entry may no longer match the query (e.g. after a
+                // rename), so the position above would land on a hidden row.
+                // reselect_after_filter_change clamps selection back into
+                // the visible set using the same rule as Refresh.
+                if matches!(self.browse_sub, BrowseSubMode::Filtering { .. }) {
+                    self.reselect_after_filter_change();
+                }
             }
             Err(e) => {
                 self.set_error(format!("Saved but rescan failed: {}", e));

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1384,10 +1384,7 @@ impl App {
                                     self.set_info(format!("Deleted '{}'", name));
                                 }
                                 Err(e) => {
-                                    self.set_error(format!(
-                                        "Failed to write snippets.json: {}",
-                                        e
-                                    ));
+                                    self.set_error(format!("Failed to write snippets.json: {}", e));
                                 }
                             }
                         }
@@ -1833,10 +1830,7 @@ impl App {
             if name != *original_name {
                 let old_path = config_dir.join(format!("{}.json", original_name));
                 if let Err(e) = std::fs::remove_file(&old_path) {
-                    self.set_error(format!(
-                        "Saved new config but failed to remove old: {}",
-                        e
-                    ));
+                    self.set_error(format!("Saved new config but failed to remove old: {}", e));
                     return;
                 }
             }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1692,16 +1692,6 @@ impl App {
             self.set_error("Snippet name cannot be empty");
             return;
         }
-        // Check builtin collision FIRST — it's a more specific error than
-        // "invalid name characters" for users who typed a builtin name
-        // verbatim (e.g. "1G memory" — has a space, also a builtin).
-        if is_builtin_snippet_name(&name) {
-            self.set_error(format!(
-                "Cannot use builtin name '{}'. Choose a different name.",
-                name
-            ));
-            return;
-        }
         if let Err(e) = crate::config::validate_config_name(&name) {
             self.set_error(format!("Invalid name: {}", e));
             return;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1793,9 +1793,13 @@ impl App {
         } else {
             Some(edit.description.value.trim().to_string())
         };
+        // Mirror snippet-save's strip rule (is_empty, not trim().is_empty)
+        // so an Args-list row left empty via EditArgsAddEmpty doesn't end
+        // up in the saved JSON as a "" token that would break launch.
+        let args: Vec<String> = edit.args.iter().filter(|a| !a.is_empty()).cloned().collect();
         let config = QemuConfig {
             qemu_bin,
-            args: edit.args.clone(),
+            args,
             desc: description,
             qemu_version: edit.preserved_qemu_version.clone(),
             resources: edit.preserved_resources.clone(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1826,13 +1826,13 @@ impl App {
             self.set_error(format!("Failed to write config: {}", e));
             return;
         }
-        if let EditMode::Update { original_name } = &edit.mode {
-            if name != *original_name {
-                let old_path = config_dir.join(format!("{}.json", original_name));
-                if let Err(e) = std::fs::remove_file(&old_path) {
-                    self.set_error(format!("Saved new config but failed to remove old: {}", e));
-                    return;
-                }
+        if let EditMode::Update { original_name } = &edit.mode
+            && name != *original_name
+        {
+            let old_path = config_dir.join(format!("{}.json", original_name));
+            if let Err(e) = std::fs::remove_file(&old_path) {
+                self.set_error(format!("Saved new config but failed to remove old: {}", e));
+                return;
             }
         }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1714,11 +1714,7 @@ impl App {
         // Read-only guard: same reasoning as LibraryDeleteConfirm. Leave the
         // edit overlay open so the user keeps their typing — only the disk
         // write is refused.
-        if let Some(err) = self
-            .library
-            .as_ref()
-            .and_then(|lib| lib.load_error.clone())
-        {
+        if let Some(err) = self.library.as_ref().and_then(|lib| lib.load_error.clone()) {
             self.set_error(format!(
                 "Cannot save: snippets.json failed to load ({}). \
                  Fix or remove the file, then reopen.",

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1873,4 +1873,3 @@ impl App {
         self.set_info(format!("Saved '{}'", entry_name));
     }
 }
-

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,4 +1,4 @@
-use super::app::{App, BrowseSubMode};
+use super::app::{App, BrowseSubMode, EditField, EditFocus, ExitConfirm, SnippetEditField};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AppEvent {
@@ -17,7 +17,182 @@ pub enum AppEvent {
     ToggleHelp,
     DismissHelp,
     Refresh,
+    // Edit mode entry (from Browse).
+    EnterEditExisting,
+    EnterEditNew,
+    // Edit mode internals.
+    EditTab,
+    EditShiftTab,
+    EditTextChar(char),
+    EditTextBackspace,
+    EditTextLeft,
+    EditTextRight,
+    EditArgsUp,
+    EditArgsDown,
+    EditArgsMoveUp,
+    EditArgsMoveDown,
+    EditArgsDelete,
+    EditSave,
+    EditCancel,
+    EditConfirmSave,
+    EditConfirmDiscard,
+    EditConfirmCancel,
+    // P4-8: Editor-pane field cycling via ↑/↓ (Tab was repurposed to
+    // switch large panes).
+    EditFieldUp,
+    EditFieldDown,
+    // P4-8: Snippets drawer events.
+    SnippetsDrawerUp,
+    SnippetsDrawerDown,
+    SnippetsDrawerToggleCollapse,
+    SnippetsDrawerEnterFilter,
+    SnippetsDrawerExitFilter,
+    SnippetsDrawerFilterChar(char),
+    SnippetsDrawerFilterBackspace,
+    SnippetsDrawerInsert,
+    // P4-10: Args token editing in Edit mode (mirrors SnippetEditToken*).
+    EditArgsAddEmpty,
+    EditArgsEnterToken,
+    EditTokenChar(char),
+    EditTokenBackspace,
+    EditTokenLeft,
+    EditTokenRight,
+    EditTokenCommit,
+    // P4-9: Library mode entry/exit + CRUD triggers
+    EnterLibrary,
+    ExitLibrary,
+    LibraryNew,
+    LibraryEditSelected,
+    LibraryDeleteSelected,
+    LibraryDeleteConfirm,
+    LibraryDeleteCancel,
+    // P4-9: SnippetEdit (nested in Library) operations
+    SnippetEditFieldUp,
+    SnippetEditFieldDown,
+    SnippetEditTextChar(char),
+    SnippetEditTextBackspace,
+    SnippetEditTextLeft,
+    SnippetEditTextRight,
+    SnippetEditCategoryPrev,
+    SnippetEditCategoryNext,
+    SnippetEditArgsUp,
+    SnippetEditArgsDown,
+    SnippetEditArgsMoveUp,
+    SnippetEditArgsMoveDown,
+    SnippetEditArgsDelete,
+    SnippetEditArgsAddEmpty,
+    SnippetEditArgsEnterToken,
+    SnippetEditTokenChar(char),
+    SnippetEditTokenBackspace,
+    SnippetEditTokenLeft,
+    SnippetEditTokenRight,
+    SnippetEditTokenCommit,
+    SnippetEditSave,
+    SnippetEditCancel,
+    SnippetEditConfirmSave,
+    SnippetEditConfirmDiscard,
+    SnippetEditConfirmCancel,
     Noop,
+}
+
+impl AppEvent {
+    /// True if this event should only be processed while in Edit mode.
+    /// `handle_event` uses this to gate Browse-only events out of Edit
+    /// and vice versa.
+    pub fn is_edit_event(&self) -> bool {
+        matches!(
+            self,
+            AppEvent::EditTab
+                | AppEvent::EditShiftTab
+                | AppEvent::EditTextChar(_)
+                | AppEvent::EditTextBackspace
+                | AppEvent::EditTextLeft
+                | AppEvent::EditTextRight
+                | AppEvent::EditArgsUp
+                | AppEvent::EditArgsDown
+                | AppEvent::EditArgsMoveUp
+                | AppEvent::EditArgsMoveDown
+                | AppEvent::EditArgsDelete
+                | AppEvent::EditSave
+                | AppEvent::EditCancel
+                | AppEvent::EditConfirmSave
+                | AppEvent::EditConfirmDiscard
+                | AppEvent::EditConfirmCancel
+                | AppEvent::EditFieldUp
+                | AppEvent::EditFieldDown
+                | AppEvent::SnippetsDrawerUp
+                | AppEvent::SnippetsDrawerDown
+                | AppEvent::SnippetsDrawerToggleCollapse
+                | AppEvent::SnippetsDrawerEnterFilter
+                | AppEvent::SnippetsDrawerExitFilter
+                | AppEvent::SnippetsDrawerFilterChar(_)
+                | AppEvent::SnippetsDrawerFilterBackspace
+                | AppEvent::SnippetsDrawerInsert
+                | AppEvent::EditArgsAddEmpty
+                | AppEvent::EditArgsEnterToken
+                | AppEvent::EditTokenChar(_)
+                | AppEvent::EditTokenBackspace
+                | AppEvent::EditTokenLeft
+                | AppEvent::EditTokenRight
+                | AppEvent::EditTokenCommit
+        )
+    }
+
+    /// True if this event should only be processed while Library mode is
+    /// active. SnippetsDrawer events are excluded here because they are
+    /// shared with Edit mode (`is_edit_event` already covers them).
+    pub fn is_library_event(&self) -> bool {
+        matches!(
+            self,
+            AppEvent::EnterLibrary
+                | AppEvent::ExitLibrary
+                | AppEvent::LibraryNew
+                | AppEvent::LibraryEditSelected
+                | AppEvent::LibraryDeleteSelected
+                | AppEvent::LibraryDeleteConfirm
+                | AppEvent::LibraryDeleteCancel
+                | AppEvent::SnippetEditFieldUp
+                | AppEvent::SnippetEditFieldDown
+                | AppEvent::SnippetEditTextChar(_)
+                | AppEvent::SnippetEditTextBackspace
+                | AppEvent::SnippetEditTextLeft
+                | AppEvent::SnippetEditTextRight
+                | AppEvent::SnippetEditCategoryPrev
+                | AppEvent::SnippetEditCategoryNext
+                | AppEvent::SnippetEditArgsUp
+                | AppEvent::SnippetEditArgsDown
+                | AppEvent::SnippetEditArgsMoveUp
+                | AppEvent::SnippetEditArgsMoveDown
+                | AppEvent::SnippetEditArgsDelete
+                | AppEvent::SnippetEditArgsAddEmpty
+                | AppEvent::SnippetEditArgsEnterToken
+                | AppEvent::SnippetEditTokenChar(_)
+                | AppEvent::SnippetEditTokenBackspace
+                | AppEvent::SnippetEditTokenLeft
+                | AppEvent::SnippetEditTokenRight
+                | AppEvent::SnippetEditTokenCommit
+                | AppEvent::SnippetEditSave
+                | AppEvent::SnippetEditCancel
+                | AppEvent::SnippetEditConfirmSave
+                | AppEvent::SnippetEditConfirmDiscard
+                | AppEvent::SnippetEditConfirmCancel
+        )
+    }
+
+    /// Drawer events shared between Edit mode (P4-8) and Library mode (P4-9).
+    pub fn is_drawer_event(&self) -> bool {
+        matches!(
+            self,
+            AppEvent::SnippetsDrawerUp
+                | AppEvent::SnippetsDrawerDown
+                | AppEvent::SnippetsDrawerToggleCollapse
+                | AppEvent::SnippetsDrawerEnterFilter
+                | AppEvent::SnippetsDrawerExitFilter
+                | AppEvent::SnippetsDrawerFilterChar(_)
+                | AppEvent::SnippetsDrawerFilterBackspace
+                | AppEvent::SnippetsDrawerInsert
+        )
+    }
 }
 
 pub fn translate_key(key: crossterm::event::KeyEvent, app: &App) -> AppEvent {
@@ -57,7 +232,6 @@ pub fn translate_key(key: crossterm::event::KeyEvent, app: &App) -> AppEvent {
             KeyCode::Up => AppEvent::NavigateUp,
             KeyCode::Down => AppEvent::NavigateDown,
             KeyCode::Char(c) => {
-                // Reject control modifier combos to avoid eating Ctrl+X etc.
                 if key
                     .modifiers
                     .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
@@ -71,7 +245,231 @@ pub fn translate_key(key: crossterm::event::KeyEvent, app: &App) -> AppEvent {
         };
     }
 
-    // 5. Idle, or Filtering { accepted: true }.
+    // 5. Edit mode dispatch (P4-7 + P4-8). Only when an Edit session is active.
+    if let Some(edit) = &app.edit {
+        // [5.1] Exit-confirm overrides everything (Ctrl+C already handled above).
+        if edit.exit_confirm == Some(ExitConfirm::Pending) {
+            return match key.code {
+                KeyCode::Char('y') => AppEvent::EditConfirmSave,
+                KeyCode::Char('n') => AppEvent::EditConfirmDiscard,
+                _ => AppEvent::EditConfirmCancel,
+            };
+        }
+
+        // [5.2] Snippets-drawer filter input is modal within the drawer.
+        if edit.focus == EditFocus::SnippetsDrawer && edit.snippets.filter.active {
+            return match (key.code, key.modifiers) {
+                (KeyCode::Esc, _) => AppEvent::SnippetsDrawerExitFilter,
+                (KeyCode::Backspace, _) => AppEvent::SnippetsDrawerFilterBackspace,
+                (KeyCode::Up, _) => AppEvent::SnippetsDrawerUp,
+                (KeyCode::Down, _) => AppEvent::SnippetsDrawerDown,
+                (KeyCode::Char(c), m)
+                    if !m.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
+                    AppEvent::SnippetsDrawerFilterChar(c)
+                }
+                _ => AppEvent::Noop,
+            };
+        }
+
+        // [5.3] Common Edit shortcuts: save / cancel / pane swap.
+        // Esc in token-edit mode commits the token instead of cancelling
+        // the whole edit session.
+        let in_token_edit = edit.focus == EditFocus::Editor
+            && edit.focused_field == EditField::Args
+            && edit.token_edit.is_some();
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('s'), m) if m.contains(KeyModifiers::CONTROL) => {
+                return AppEvent::EditSave;
+            }
+            (KeyCode::Esc, _) if in_token_edit => return AppEvent::EditTokenCommit,
+            (KeyCode::Esc, _) => return AppEvent::EditCancel,
+            (KeyCode::BackTab, _) => return AppEvent::EditShiftTab,
+            (KeyCode::Tab, m) if m.contains(KeyModifiers::SHIFT) => {
+                return AppEvent::EditShiftTab;
+            }
+            (KeyCode::Tab, _) => return AppEvent::EditTab,
+            _ => {}
+        }
+
+        // [5.4] Per-pane dispatch.
+        return match edit.focus {
+            EditFocus::Editor => match edit.focused_field {
+                EditField::Args => {
+                    // P4-10: token edit modal — takes precedence inside Args.
+                    if edit.token_edit.is_some() {
+                        return match (key.code, key.modifiers) {
+                            (KeyCode::Enter, _) | (KeyCode::Esc, _) => {
+                                AppEvent::EditTokenCommit
+                            }
+                            (KeyCode::Backspace, _) => AppEvent::EditTokenBackspace,
+                            (KeyCode::Left, _) => AppEvent::EditTokenLeft,
+                            (KeyCode::Right, _) => AppEvent::EditTokenRight,
+                            (KeyCode::Char(c), m)
+                                if !m.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                            {
+                                AppEvent::EditTokenChar(c)
+                            }
+                            _ => AppEvent::Noop,
+                        };
+                    }
+                    match (key.code, key.modifiers) {
+                        (KeyCode::Up, _) => AppEvent::EditArgsUp,
+                        (KeyCode::Down, _) => AppEvent::EditArgsDown,
+                        (KeyCode::Char('K'), _) => AppEvent::EditArgsMoveUp,
+                        (KeyCode::Char('J'), _) => AppEvent::EditArgsMoveDown,
+                        (KeyCode::Char('d'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                            AppEvent::EditArgsDelete
+                        }
+                        // P4-10: new args operations.
+                        (KeyCode::Char('a'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                            AppEvent::EditArgsAddEmpty
+                        }
+                        (KeyCode::Enter, _) => AppEvent::EditArgsEnterToken,
+                        _ => AppEvent::Noop,
+                    }
+                }
+                _ => match (key.code, key.modifiers) {
+                    (KeyCode::Up, _) => AppEvent::EditFieldUp,
+                    (KeyCode::Down, _) => AppEvent::EditFieldDown,
+                    (KeyCode::Backspace, _) => AppEvent::EditTextBackspace,
+                    (KeyCode::Left, _) => AppEvent::EditTextLeft,
+                    (KeyCode::Right, _) => AppEvent::EditTextRight,
+                    (KeyCode::Char(c), m)
+                        if !m.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        AppEvent::EditTextChar(c)
+                    }
+                    _ => AppEvent::Noop,
+                },
+            },
+            EditFocus::SnippetsDrawer => match (key.code, key.modifiers) {
+                (KeyCode::Up, _) => AppEvent::SnippetsDrawerUp,
+                (KeyCode::Down, _) => AppEvent::SnippetsDrawerDown,
+                (KeyCode::Char(' '), _) => AppEvent::SnippetsDrawerToggleCollapse,
+                (KeyCode::Char('/'), _) => AppEvent::SnippetsDrawerEnterFilter,
+                (KeyCode::Right, _) => AppEvent::SnippetsDrawerInsert,
+                _ => AppEvent::Noop,
+            },
+        };
+    }
+
+    // 6. Library mode dispatch (P4-9). Only when a Library session is active.
+    if let Some(lib) = &app.library {
+        // [6.1] Nested SnippetEdit overrides Library browse.
+        if let Some(sedit) = &lib.edit {
+            // [6.1.1] Token edit modal.
+            if sedit.token_edit.is_some() {
+                return match (key.code, key.modifiers) {
+                    (KeyCode::Enter, _) | (KeyCode::Esc, _) => AppEvent::SnippetEditTokenCommit,
+                    (KeyCode::Backspace, _) => AppEvent::SnippetEditTokenBackspace,
+                    (KeyCode::Left, _) => AppEvent::SnippetEditTokenLeft,
+                    (KeyCode::Right, _) => AppEvent::SnippetEditTokenRight,
+                    (KeyCode::Char(c), m)
+                        if !m.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        AppEvent::SnippetEditTokenChar(c)
+                    }
+                    _ => AppEvent::Noop,
+                };
+            }
+            // [6.1.2] Exit-confirm modal.
+            if sedit.exit_confirm == Some(ExitConfirm::Pending) {
+                return match key.code {
+                    KeyCode::Char('y') => AppEvent::SnippetEditConfirmSave,
+                    KeyCode::Char('n') => AppEvent::SnippetEditConfirmDiscard,
+                    _ => AppEvent::SnippetEditConfirmCancel,
+                };
+            }
+            // [6.1.3] Common SnippetEdit shortcuts.
+            match (key.code, key.modifiers) {
+                (KeyCode::Char('s'), m) if m.contains(KeyModifiers::CONTROL) => {
+                    return AppEvent::SnippetEditSave;
+                }
+                (KeyCode::Esc, _) => return AppEvent::SnippetEditCancel,
+                _ => {}
+            }
+            // [6.1.4] Per-field dispatch.
+            return match sedit.focused_field {
+                SnippetEditField::Args => match (key.code, key.modifiers) {
+                    (KeyCode::Up, _) => AppEvent::SnippetEditArgsUp,
+                    (KeyCode::Down, _) => AppEvent::SnippetEditArgsDown,
+                    (KeyCode::Char('K'), _) => AppEvent::SnippetEditArgsMoveUp,
+                    (KeyCode::Char('J'), _) => AppEvent::SnippetEditArgsMoveDown,
+                    (KeyCode::Char('d'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                        AppEvent::SnippetEditArgsDelete
+                    }
+                    (KeyCode::Char('a'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                        AppEvent::SnippetEditArgsAddEmpty
+                    }
+                    (KeyCode::Enter, _) => AppEvent::SnippetEditArgsEnterToken,
+                    _ => AppEvent::Noop,
+                },
+                SnippetEditField::Category => match (key.code, key.modifiers) {
+                    (KeyCode::Up, _) => AppEvent::SnippetEditFieldUp,
+                    (KeyCode::Down, _) => AppEvent::SnippetEditFieldDown,
+                    (KeyCode::Left, _) => AppEvent::SnippetEditCategoryPrev,
+                    (KeyCode::Right, _) => AppEvent::SnippetEditCategoryNext,
+                    _ => AppEvent::Noop,
+                },
+                _ => match (key.code, key.modifiers) {
+                    (KeyCode::Up, _) => AppEvent::SnippetEditFieldUp,
+                    (KeyCode::Down, _) => AppEvent::SnippetEditFieldDown,
+                    (KeyCode::Backspace, _) => AppEvent::SnippetEditTextBackspace,
+                    (KeyCode::Left, _) => AppEvent::SnippetEditTextLeft,
+                    (KeyCode::Right, _) => AppEvent::SnippetEditTextRight,
+                    (KeyCode::Char(c), m)
+                        if !m.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        AppEvent::SnippetEditTextChar(c)
+                    }
+                    _ => AppEvent::Noop,
+                },
+            };
+        }
+        // [6.2] Delete-confirm modal.
+        if lib.delete_confirm.is_some() {
+            return match key.code {
+                KeyCode::Char('y') => AppEvent::LibraryDeleteConfirm,
+                _ => AppEvent::LibraryDeleteCancel,
+            };
+        }
+        // [6.3] Library snippets-drawer filter modal.
+        if lib.snippets.filter.active {
+            return match (key.code, key.modifiers) {
+                (KeyCode::Esc, _) => AppEvent::SnippetsDrawerExitFilter,
+                (KeyCode::Backspace, _) => AppEvent::SnippetsDrawerFilterBackspace,
+                (KeyCode::Up, _) => AppEvent::SnippetsDrawerUp,
+                (KeyCode::Down, _) => AppEvent::SnippetsDrawerDown,
+                (KeyCode::Char(c), m)
+                    if !m.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
+                    AppEvent::SnippetsDrawerFilterChar(c)
+                }
+                _ => AppEvent::Noop,
+            };
+        }
+        // [6.4] Library browse dispatch.
+        return match (key.code, key.modifiers) {
+            (KeyCode::Char('l'), m) if m.contains(KeyModifiers::CONTROL) => AppEvent::ExitLibrary,
+            (KeyCode::Esc, _) => AppEvent::ExitLibrary,
+            (KeyCode::Up, _) => AppEvent::SnippetsDrawerUp,
+            (KeyCode::Down, _) => AppEvent::SnippetsDrawerDown,
+            (KeyCode::Char(' '), _) => AppEvent::SnippetsDrawerToggleCollapse,
+            (KeyCode::Char('/'), _) => AppEvent::SnippetsDrawerEnterFilter,
+            (KeyCode::Char('n'), m) if !m.contains(KeyModifiers::CONTROL) => AppEvent::LibraryNew,
+            (KeyCode::Char('e'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                AppEvent::LibraryEditSelected
+            }
+            (KeyCode::Char('d'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                AppEvent::LibraryDeleteSelected
+            }
+            (KeyCode::Char('?'), _) => AppEvent::ToggleHelp,
+            _ => AppEvent::Noop,
+        };
+    }
+
+    // 7. Idle, or Filtering { accepted: true }.
     let accepted_filter = matches!(
         &app.browse_sub,
         BrowseSubMode::Filtering { accepted: true, .. }
@@ -89,6 +487,9 @@ pub fn translate_key(key: crossterm::event::KeyEvent, app: &App) -> AppEvent {
         (KeyCode::Char('?'), _) => AppEvent::ToggleHelp,
         (KeyCode::Char('/'), _) => AppEvent::EnterFilter,
         (KeyCode::Char('r'), _) => AppEvent::Refresh,
+        (KeyCode::Char('l'), m) if m.contains(KeyModifiers::CONTROL) => AppEvent::EnterLibrary,
+        (KeyCode::Char('e'), _) => AppEvent::EnterEditExisting,
+        (KeyCode::Char('n'), _) => AppEvent::EnterEditNew,
         (KeyCode::Char('j'), _) => AppEvent::NavigateDown,
         (KeyCode::Down, _) => AppEvent::NavigateDown,
         (KeyCode::Char('k'), _) => AppEvent::NavigateUp,

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -299,9 +299,7 @@ pub fn translate_key(key: crossterm::event::KeyEvent, app: &App) -> AppEvent {
                     // P4-10: token edit modal — takes precedence inside Args.
                     if edit.token_edit.is_some() {
                         return match (key.code, key.modifiers) {
-                            (KeyCode::Enter, _) | (KeyCode::Esc, _) => {
-                                AppEvent::EditTokenCommit
-                            }
+                            (KeyCode::Enter, _) | (KeyCode::Esc, _) => AppEvent::EditTokenCommit,
                             (KeyCode::Backspace, _) => AppEvent::EditTokenBackspace,
                             (KeyCode::Left, _) => AppEvent::EditTokenLeft,
                             (KeyCode::Right, _) => AppEvent::EditTokenRight,

--- a/src/tui/render/edit_pane.rs
+++ b/src/tui/render/edit_pane.rs
@@ -330,11 +330,6 @@ fn render_snippets_list(f: &mut Frame, area: Rect, edit: &EditState) {
     let drawer_focused = edit.focus == EditFocus::SnippetsDrawer;
     let selected = edit.snippets.selected;
 
-    let builtin_names: std::collections::HashSet<String> = crate::snippets::builtin_snippets()
-        .into_iter()
-        .map(|s| s.name)
-        .collect();
-
     let items: Vec<ListItem> = rows
         .iter()
         .enumerate()
@@ -367,10 +362,12 @@ fn render_snippets_list(f: &mut Frame, area: Rect, edit: &EditState) {
                 DrawerRow::Snippet { snippet_index } => {
                     let snippet = &edit.snippets.snippets[*snippet_index];
                     let indicator = if is_selected { "▸ " } else { "  " };
-                    let badge = if builtin_names.contains(&snippet.name) {
-                        Span::styled(" [builtin]", theme::dim_style())
-                    } else {
+                    let is_user_owned =
+                        edit.user_only_snippets.iter().any(|u| u.name == snippet.name);
+                    let badge = if is_user_owned {
                         Span::styled(" [user]", Style::default().fg(theme::BADGE_LIBRARY_BG))
+                    } else {
+                        Span::styled(" [builtin]", theme::dim_style())
                     };
                     let line = Line::from(vec![
                         Span::styled("    ", theme::dim_style()),

--- a/src/tui/render/edit_pane.rs
+++ b/src/tui/render/edit_pane.rs
@@ -362,8 +362,10 @@ fn render_snippets_list(f: &mut Frame, area: Rect, edit: &EditState) {
                 DrawerRow::Snippet { snippet_index } => {
                     let snippet = &edit.snippets.snippets[*snippet_index];
                     let indicator = if is_selected { "▸ " } else { "  " };
-                    let is_user_owned =
-                        edit.user_only_snippets.iter().any(|u| u.name == snippet.name);
+                    let is_user_owned = edit
+                        .user_only_snippets
+                        .iter()
+                        .any(|u| u.name == snippet.name);
                     let badge = if is_user_owned {
                         Span::styled(" [user]", Style::default().fg(theme::BADGE_LIBRARY_BG))
                     } else {

--- a/src/tui/render/edit_pane.rs
+++ b/src/tui/render/edit_pane.rs
@@ -1,0 +1,388 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph},
+};
+
+use crate::tui::app::{
+    App, DrawerRow, EditField, EditFocus, EditMode, EditState, ExitConfirm, TextField,
+};
+use crate::tui::theme;
+
+pub(super) fn render(f: &mut Frame, area: Rect, app: &App) {
+    let Some(edit) = &app.edit else {
+        return;
+    };
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(area);
+
+    render_editor_pane(f, cols[0], edit);
+    render_snippets_drawer(f, cols[1], edit);
+}
+
+fn render_editor_pane(f: &mut Frame, area: Rect, edit: &EditState) {
+    let editor_focused = edit.focus == EditFocus::Editor;
+    let border_style = if editor_focused {
+        theme::accent_style()
+    } else {
+        theme::border_style()
+    };
+    let title_text = match &edit.mode {
+        EditMode::Create => " Editing: new configuration ".to_string(),
+        EditMode::Update { original_name } => format!(" Editing: {} ", original_name),
+    };
+    let title_style = if editor_focused {
+        theme::accent_style().add_modifier(Modifier::BOLD)
+    } else {
+        theme::dim_style().add_modifier(Modifier::BOLD)
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(border_style)
+        .title(Span::styled(title_text, title_style));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Min(3),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    render_text_field(
+        f,
+        rows[1],
+        "Name",
+        &edit.name,
+        editor_focused && edit.focused_field == EditField::Name,
+    );
+    render_text_field(
+        f,
+        rows[2],
+        "QEMU binary",
+        &edit.qemu_bin,
+        editor_focused && edit.focused_field == EditField::QemuBin,
+    );
+    render_text_field(
+        f,
+        rows[3],
+        "Description",
+        &edit.description,
+        editor_focused && edit.focused_field == EditField::Description,
+    );
+
+    let args_focused = editor_focused && edit.focused_field == EditField::Args;
+    let args_label_style = if args_focused {
+        theme::accent_style().add_modifier(Modifier::BOLD)
+    } else {
+        theme::dim_style()
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled("  Args", args_label_style))),
+        rows[4],
+    );
+
+    render_args_list(
+        f,
+        rows[5],
+        &edit.args,
+        edit.args_selected,
+        args_focused,
+        edit.token_edit.as_ref(),
+    );
+
+    let res_line = if edit.preserved_resources.is_empty() {
+        Line::from(vec![
+            Span::styled("  Resources  ", theme::dim_style()),
+            Span::styled("(none)", theme::dim_style()),
+            Span::styled("    ", theme::dim_style()),
+            Span::styled("(read-only, edit via CLI)", theme::dim_style()),
+        ])
+    } else {
+        let mut keys: Vec<&String> = edit.preserved_resources.keys().collect();
+        keys.sort();
+        let key_list = keys
+            .iter()
+            .map(|k| k.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Line::from(vec![
+            Span::styled("  Resources  ", theme::dim_style()),
+            Span::raw(key_list),
+            Span::styled("    ", theme::dim_style()),
+            Span::styled("(read-only, edit via CLI)", theme::dim_style()),
+        ])
+    };
+    f.render_widget(Paragraph::new(res_line), rows[6]);
+
+    if edit.exit_confirm == Some(ExitConfirm::Pending) {
+        let prompt = Line::from(vec![
+            Span::styled(
+                "  Save changes? ",
+                Style::default()
+                    .fg(theme::WARN)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("[y] save  [n] discard  ", theme::dim_style()),
+            Span::styled("(any other key to cancel)", theme::dim_style()),
+        ]);
+        f.render_widget(Paragraph::new(prompt), rows[7]);
+    } else if edit.dirty {
+        let dirty = Line::from(vec![
+            Span::styled("  ●", Style::default().fg(theme::WARN)),
+            Span::styled(" unsaved changes", theme::dim_style()),
+        ]);
+        f.render_widget(Paragraph::new(dirty), rows[7]);
+    }
+}
+
+fn render_text_field(f: &mut Frame, area: Rect, label: &str, field: &TextField, focused: bool) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let label_style = if focused {
+        theme::accent_style().add_modifier(Modifier::BOLD)
+    } else {
+        theme::dim_style()
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!("  {}", label),
+            label_style,
+        ))),
+        rows[0],
+    );
+
+    let mut spans: Vec<Span<'static>> = vec![Span::styled("  [ ", theme::dim_style())];
+    if focused {
+        let cursor = field.cursor.min(field.value.len());
+        spans.push(Span::raw(field.value[..cursor].to_string()));
+        spans.push(Span::styled("█", theme::accent_style()));
+        spans.push(Span::raw(field.value[cursor..].to_string()));
+    } else {
+        spans.push(Span::raw(field.value.clone()));
+    }
+    spans.push(Span::styled(" ]", theme::dim_style()));
+    f.render_widget(Paragraph::new(Line::from(spans)), rows[1]);
+}
+
+fn render_args_list(
+    f: &mut Frame,
+    area: Rect,
+    args: &[String],
+    selected: usize,
+    focused: bool,
+    token_edit: Option<&TextField>,
+) {
+    if args.is_empty() {
+        let placeholder = Line::from(vec![
+            Span::styled("    ", theme::dim_style()),
+            Span::styled(
+                "(no args — Tab to Snippets drawer, → to insert one; or 'a' to add)",
+                theme::dim_style(),
+            ),
+        ]);
+        f.render_widget(Paragraph::new(placeholder), area);
+        return;
+    }
+
+    let items: Vec<ListItem> = args
+        .iter()
+        .enumerate()
+        .map(|(i, arg)| {
+            let is_selected = focused && i == selected;
+            let indicator = if is_selected { "▸ " } else { "  " };
+            let mut line_spans: Vec<Span<'static>> = vec![
+                Span::raw("  "),
+                Span::styled(indicator, theme::accent_style()),
+                Span::styled(format!("[{}] ", i), theme::dim_style()),
+            ];
+            if let Some(token) = token_edit.filter(|_| is_selected) {
+                let cursor = token.cursor.min(token.value.len());
+                line_spans.push(Span::raw(token.value[..cursor].to_string()));
+                line_spans.push(Span::styled("█", theme::accent_style()));
+                line_spans.push(Span::raw(token.value[cursor..].to_string()));
+            } else {
+                line_spans.push(Span::raw(arg.clone()));
+            }
+            ListItem::new(Line::from(line_spans))
+        })
+        .collect();
+
+    let list = List::new(items);
+    let mut state = ListState::default();
+    if focused {
+        state.select(Some(selected));
+    }
+    f.render_stateful_widget(list, area, &mut state);
+}
+
+// --- Snippets drawer -----------------------------------------------------
+
+fn render_snippets_drawer(f: &mut Frame, area: Rect, edit: &EditState) {
+    let drawer_focused = edit.focus == EditFocus::SnippetsDrawer;
+    let border_style = if drawer_focused {
+        theme::accent_style()
+    } else {
+        theme::border_style()
+    };
+    let title = if let Some(err) = &edit.snippets.load_error {
+        Span::styled(
+            format!(" Snippets · {} ", err),
+            Style::default().fg(theme::WARN),
+        )
+    } else if edit.snippets.filter.active {
+        Span::styled(
+            " Snippets · filter ".to_string(),
+            theme::accent_style().add_modifier(Modifier::BOLD),
+        )
+    } else {
+        let title_style = if drawer_focused {
+            theme::accent_style().add_modifier(Modifier::BOLD)
+        } else {
+            theme::dim_style().add_modifier(Modifier::BOLD)
+        };
+        Span::styled(" Snippets ".to_string(), title_style)
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(border_style)
+        .title(title);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if edit.snippets.filter.active {
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(inner);
+        render_filter_input(f, layout[1], &edit.snippets.filter.query);
+        let sep: String = "─".repeat(layout[2].width as usize);
+        f.render_widget(Paragraph::new(sep).style(theme::dim_style()), layout[2]);
+        render_snippets_list(f, layout[3], edit);
+    } else {
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(inner);
+        render_snippets_list(f, layout[1], edit);
+    }
+}
+
+fn render_filter_input(f: &mut Frame, area: Rect, query: &TextField) {
+    let line = Line::from(vec![
+        Span::styled("  / ", theme::accent_style()),
+        Span::raw(query.value.clone()),
+        Span::styled("█", theme::accent_style()),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn render_snippets_list(f: &mut Frame, area: Rect, edit: &EditState) {
+    let rows = edit.snippets.visible_rows();
+
+    if rows.is_empty() {
+        let msg = if edit.snippets.snippets.is_empty() {
+            "  (no snippets loaded)"
+        } else if edit.snippets.filter.active && !edit.snippets.filter.query.value.is_empty() {
+            "  (no matching snippets)"
+        } else {
+            "  (no snippets to show)"
+        };
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(msg, theme::dim_style()))),
+            area,
+        );
+        return;
+    }
+
+    let drawer_focused = edit.focus == EditFocus::SnippetsDrawer;
+    let selected = edit.snippets.selected;
+
+    let builtin_names: std::collections::HashSet<String> = crate::snippets::builtin_snippets()
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+
+    let items: Vec<ListItem> = rows
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let is_selected = drawer_focused && i == selected;
+            match row {
+                DrawerRow::CategoryHeader {
+                    category,
+                    collapsed,
+                    snippet_count,
+                } => {
+                    let chevron = if *collapsed { "▶" } else { "▼" };
+                    let indicator = if is_selected { "▸ " } else { "  " };
+                    let count_suffix = if *collapsed {
+                        format!(" ({} hidden)", snippet_count)
+                    } else {
+                        String::new()
+                    };
+                    let line = Line::from(vec![
+                        Span::styled(indicator, theme::accent_style()),
+                        Span::styled(format!("{} ", chevron), theme::dim_style()),
+                        Span::styled(
+                            format!("{:?}", category),
+                            theme::accent_style().add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(count_suffix, theme::dim_style()),
+                    ]);
+                    ListItem::new(line)
+                }
+                DrawerRow::Snippet { snippet_index } => {
+                    let snippet = &edit.snippets.snippets[*snippet_index];
+                    let indicator = if is_selected { "▸ " } else { "  " };
+                    let badge = if builtin_names.contains(&snippet.name) {
+                        Span::styled(" [builtin]", theme::dim_style())
+                    } else {
+                        Span::styled(" [user]", Style::default().fg(theme::BADGE_LIBRARY_BG))
+                    };
+                    let line = Line::from(vec![
+                        Span::styled("    ", theme::dim_style()),
+                        Span::styled(indicator, theme::accent_style()),
+                        Span::raw(snippet.name.clone()),
+                        badge,
+                    ]);
+                    ListItem::new(line)
+                }
+            }
+        })
+        .collect();
+
+    f.render_widget(List::new(items), area);
+}

--- a/src/tui/render/help.rs
+++ b/src/tui/render/help.rs
@@ -8,29 +8,81 @@ use ratatui::{
 use crate::tui::app::App;
 use crate::tui::theme;
 
-pub(super) fn render(f: &mut Frame, full: Rect, _app: &App) {
-    // Only cap the upper bound. Skipping the lower bound prevents
-    // producing a Rect that exceeds the frame on tiny terminals — ratatui
-    // would panic inside `render_widget` when the rect overflows.
+pub(super) fn render(f: &mut Frame, full: Rect, app: &App) {
     let w = full.width.min(64);
-    let h = full.height.min(24);
+    let h = full.height.min(28);
     let x = full.x + full.width.saturating_sub(w) / 2;
     let y = full.y + full.height.saturating_sub(h) / 2;
     let area = Rect::new(x, y, w, h);
 
     f.render_widget(Clear, area);
 
+    let title = if app.library.is_some() {
+        " Help · Library mode "
+    } else if app.edit.is_some() {
+        " Help · Edit mode "
+    } else {
+        " Help · Browse mode "
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(theme::accent_style())
-        .title(Span::styled(" Help · Browse mode ", theme::accent_style()));
+        .title(Span::styled(title, theme::accent_style()));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
+    let lines = if app.library.is_some() {
+        library_help_lines()
+    } else if app.edit.is_some() {
+        edit_help_lines()
+    } else {
+        browse_help_lines()
+    };
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+}
+
+fn library_help_lines() -> Vec<Line<'static>> {
     let accent = theme::accent_style();
     let dim = theme::dim_style();
-    let lines: Vec<Line<'static>> = vec![
+    vec![
+        Line::from(""),
+        Line::from(Span::styled("  Library", accent)),
+        Line::from("    Ctrl+L              exit library"),
+        Line::from("    ↑ / ↓               navigate"),
+        Line::from("    Space               toggle category collapse"),
+        Line::from("    /                   filter"),
+        Line::from("    n                   create new snippet"),
+        Line::from("    e                   edit selected user snippet"),
+        Line::from("    d                   delete selected user snippet"),
+        Line::from("    Esc                 same as Ctrl+L"),
+        Line::from(""),
+        Line::from(Span::styled("  Snippet Editing", accent)),
+        Line::from("    ↑ / ↓               field cycle"),
+        Line::from("    ← / →               cursor (text) or change category"),
+        Line::from("    Enter               edit selected arg token (in Args)"),
+        Line::from("    a                   add empty arg (in Args)"),
+        Line::from("    J / K               reorder args"),
+        Line::from("    d                   delete selected arg"),
+        Line::from("    Ctrl+S              save and close edit"),
+        Line::from("    Esc                 cancel (confirms if unsaved)"),
+        Line::from(""),
+        Line::from(Span::styled("  Token edit", accent)),
+        Line::from("    Enter / Esc         commit token, exit token edit"),
+        Line::from("    ← / →               cursor"),
+        Line::from("    Backspace           delete char"),
+        Line::from(""),
+        Line::from(Span::styled("  Exit", accent)),
+        Line::from("    Ctrl+C              always quit"),
+        Line::from(""),
+        Line::from(Span::styled("  Press any key to close this help.", dim)),
+    ]
+}
+
+fn browse_help_lines() -> Vec<Line<'static>> {
+    let accent = theme::accent_style();
+    let dim = theme::dim_style();
+    vec![
         Line::from(""),
         Line::from(Span::styled("  Navigation", accent)),
         Line::from("    j  ↓     move down"),
@@ -41,6 +93,9 @@ pub(super) fn render(f: &mut Frame, full: Rect, _app: &App) {
         Line::from(""),
         Line::from(Span::styled("  Actions", accent)),
         Line::from("    Enter    launch selected QEMU"),
+        Line::from("    e        edit selected configuration"),
+        Line::from("    n        create new configuration"),
+        Line::from("    Ctrl+L   open snippets library"),
         Line::from("    /        enter filter mode"),
         Line::from("    r        reload configurations"),
         Line::from("    ?        toggle this help"),
@@ -55,8 +110,38 @@ pub(super) fn render(f: &mut Frame, full: Rect, _app: &App) {
         Line::from("    Ctrl+C   force quit"),
         Line::from(""),
         Line::from(Span::styled("  Press any key to close this help.", dim)),
-    ];
+    ]
+}
 
-    let p = Paragraph::new(lines).wrap(Wrap { trim: false });
-    f.render_widget(p, inner);
+fn edit_help_lines() -> Vec<Line<'static>> {
+    let accent = theme::accent_style();
+    let dim = theme::dim_style();
+    vec![
+        Line::from(""),
+        Line::from(Span::styled("  Navigation", accent)),
+        Line::from("    Tab / Shift+Tab   switch pane (Editor ↔ Snippets)"),
+        Line::from("    ↑ / ↓             field cycle (Editor) / row nav (Snippets)"),
+        Line::from("    ← / →             cursor move (text fields)"),
+        Line::from("    Space             toggle category collapse (Snippets)"),
+        Line::from("    /                 enter filter (Snippets)"),
+        Line::from(""),
+        Line::from(Span::styled("  Actions", accent)),
+        Line::from("    →                 insert snippet into args (Snippets)"),
+        Line::from("    a                 add empty arg + edit (Args field)"),
+        Line::from("    Enter             edit selected arg token (Args field)"),
+        Line::from("    J / K             reorder args down/up (Args field)"),
+        Line::from("    d                 delete current arg (Args field)"),
+        Line::from("    Ctrl+S            save and exit"),
+        Line::from("    Esc               cancel (confirms if unsaved)"),
+        Line::from(""),
+        Line::from(Span::styled("  Token edit", accent)),
+        Line::from("    Enter / Esc       commit token, exit token edit"),
+        Line::from("    ← / →             cursor"),
+        Line::from("    Backspace         delete char"),
+        Line::from(""),
+        Line::from(Span::styled("  Exit", accent)),
+        Line::from("    Ctrl+C            always quit"),
+        Line::from(""),
+        Line::from(Span::styled("  Press any key to close this help.", dim)),
+    ]
 }

--- a/src/tui/render/library_pane.rs
+++ b/src/tui/render/library_pane.rs
@@ -1,0 +1,466 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use crate::tui::app::{
+    App, DrawerRow, LibraryState, SnippetEditField, SnippetEditMode, SnippetEditState,
+    SnippetsDrawerState, TextField, is_builtin_snippet_name,
+};
+use crate::tui::theme;
+
+pub(super) fn render(f: &mut Frame, area: Rect, app: &App) {
+    let Some(lib) = &app.library else {
+        return;
+    };
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    render_left_tree(f, cols[0], lib);
+
+    if let Some(sedit) = &lib.edit {
+        render_snippet_editor(f, cols[1], sedit);
+    } else {
+        render_right_detail(f, cols[1], lib);
+    }
+}
+
+fn render_left_tree(f: &mut Frame, area: Rect, lib: &LibraryState) {
+    let focused = lib.edit.is_none() && lib.delete_confirm.is_none();
+    let border_style = if focused {
+        Style::default().fg(theme::BADGE_LIBRARY_BG)
+    } else {
+        theme::border_style()
+    };
+    let title_style = if focused {
+        Style::default()
+            .fg(theme::BADGE_LIBRARY_BG)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        theme::dim_style().add_modifier(Modifier::BOLD)
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(border_style)
+        .title(Span::styled(" Snippets Library ", title_style));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if lib.snippets.filter.active {
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(inner);
+        render_filter_input(f, layout[1], &lib.snippets.filter.query);
+        let sep: String = "─".repeat(layout[2].width as usize);
+        f.render_widget(Paragraph::new(sep).style(theme::dim_style()), layout[2]);
+        render_drawer_list(f, layout[3], &lib.snippets, focused);
+    } else {
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(inner);
+        render_drawer_list(f, layout[1], &lib.snippets, focused);
+    }
+}
+
+fn render_filter_input(f: &mut Frame, area: Rect, query: &TextField) {
+    let line = Line::from(vec![
+        Span::styled("  / ", theme::accent_style()),
+        Span::raw(query.value.clone()),
+        Span::styled("█", theme::accent_style()),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn render_drawer_list(f: &mut Frame, area: Rect, drawer: &SnippetsDrawerState, focused: bool) {
+    let rows = drawer.visible_rows();
+    if rows.is_empty() {
+        let msg = if drawer.snippets.is_empty() {
+            "  (no snippets loaded)"
+        } else if drawer.filter.active && !drawer.filter.query.value.is_empty() {
+            "  (no matching snippets)"
+        } else {
+            "  (no snippets to show)"
+        };
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(msg, theme::dim_style()))),
+            area,
+        );
+        return;
+    }
+    let items: Vec<ListItem> = rows
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let is_selected = focused && i == drawer.selected;
+            match row {
+                DrawerRow::CategoryHeader {
+                    category,
+                    collapsed,
+                    snippet_count,
+                } => {
+                    let chevron = if *collapsed { "▶" } else { "▼" };
+                    let indicator = if is_selected { "▸ " } else { "  " };
+                    let count_suffix = if *collapsed {
+                        format!(" ({} hidden)", snippet_count)
+                    } else {
+                        String::new()
+                    };
+                    ListItem::new(Line::from(vec![
+                        Span::styled(indicator, theme::accent_style()),
+                        Span::styled(format!("{} ", chevron), theme::dim_style()),
+                        Span::styled(
+                            format!("{:?}", category),
+                            theme::accent_style().add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(count_suffix, theme::dim_style()),
+                    ]))
+                }
+                DrawerRow::Snippet { snippet_index } => {
+                    let snippet = &drawer.snippets[*snippet_index];
+                    let indicator = if is_selected { "▸ " } else { "  " };
+                    let badge = if is_builtin_snippet_name(&snippet.name) {
+                        Span::styled(" [builtin]", theme::dim_style())
+                    } else {
+                        Span::styled(" [user]", Style::default().fg(theme::BADGE_LIBRARY_BG))
+                    };
+                    ListItem::new(Line::from(vec![
+                        Span::styled("    ", theme::dim_style()),
+                        Span::styled(indicator, theme::accent_style()),
+                        Span::raw(snippet.name.clone()),
+                        badge,
+                    ]))
+                }
+            }
+        })
+        .collect();
+    let mut state = ListState::default();
+    state.select(Some(drawer.selected));
+    f.render_stateful_widget(List::new(items), area, &mut state);
+}
+
+fn render_right_detail(f: &mut Frame, area: Rect, lib: &LibraryState) {
+    if let Some(confirm) = &lib.delete_confirm {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme::BAD))
+            .title(Span::styled(
+                " Confirm deletion ",
+                Style::default().fg(theme::BAD).add_modifier(Modifier::BOLD),
+            ));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        let lines = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  Delete user snippet '{}' ?", confirm.snippet_name),
+                Style::default().fg(theme::BAD).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  [y] delete    [n] cancel    (any other key to cancel)",
+                theme::dim_style(),
+            )),
+        ];
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+        return;
+    }
+
+    let snippet = match lib.snippets.current_row() {
+        Some(DrawerRow::Snippet { snippet_index }) => lib.snippets.snippets.get(snippet_index),
+        _ => None,
+    };
+    let Some(snippet) = snippet else {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "  (select a snippet to view details)",
+            theme::dim_style(),
+        )));
+        f.render_widget(p, area);
+        return;
+    };
+    let is_builtin = is_builtin_snippet_name(&snippet.name);
+
+    let mut lines: Vec<Line<'static>> = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                format!("  {}", snippet.name),
+                Style::default()
+                    .fg(theme::BADGE_LIBRARY_BG)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            if is_builtin {
+                Span::styled("[builtin]", theme::dim_style())
+            } else {
+                Span::styled("[user]", Style::default().fg(theme::BADGE_LIBRARY_BG))
+            },
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Category     ", theme::dim_style()),
+            Span::raw(format!("{:?}", snippet.category)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Description  ", theme::dim_style()),
+            Span::raw(
+                snippet
+                    .description
+                    .clone()
+                    .unwrap_or_else(|| "(none)".to_string()),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled("  Args", theme::dim_style())),
+    ];
+    if snippet.args.is_empty() {
+        lines.push(Line::from(Span::styled("    (none)", theme::dim_style())));
+    } else {
+        for (i, arg) in snippet.args.iter().enumerate() {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(format!("[{}]  ", i), theme::dim_style()),
+                Span::raw(arg.clone()),
+            ]));
+        }
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("  Source       ", theme::dim_style()),
+        if is_builtin {
+            Span::styled("builtin (read-only)", theme::dim_style())
+        } else {
+            Span::styled(
+                "user (~/.vex/snippets.json)",
+                Style::default().fg(theme::BADGE_LIBRARY_BG),
+            )
+        },
+    ]));
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+}
+
+// --- Snippet editor (right pane when lib.edit is Some) ------------------
+
+fn render_snippet_editor(f: &mut Frame, area: Rect, sedit: &SnippetEditState) {
+    let title_text = match &sedit.mode {
+        SnippetEditMode::Create => " Editing: new snippet ".to_string(),
+        SnippetEditMode::Update { original_name } => {
+            format!(" Editing: {} ", original_name)
+        }
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme::BADGE_EDIT_BG))
+        .title(Span::styled(
+            title_text,
+            Style::default()
+                .fg(theme::BADGE_EDIT_BG)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Min(3),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    render_text_field(
+        f,
+        rows[1],
+        "Name",
+        &sedit.name,
+        sedit.focused_field == SnippetEditField::Name,
+    );
+    render_category_field(f, rows[2], sedit);
+    render_text_field(
+        f,
+        rows[3],
+        "Description",
+        &sedit.description,
+        sedit.focused_field == SnippetEditField::Description,
+    );
+
+    let args_focused = sedit.focused_field == SnippetEditField::Args;
+    let args_label_style = if args_focused {
+        Style::default()
+            .fg(theme::BADGE_EDIT_BG)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        theme::dim_style()
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled("  Args", args_label_style))),
+        rows[4],
+    );
+    render_args_field(f, rows[5], sedit);
+
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Source       ", theme::dim_style()),
+            Span::styled(
+                "user (~/.vex/snippets.json)",
+                Style::default().fg(theme::BADGE_LIBRARY_BG),
+            ),
+        ])),
+        rows[6],
+    );
+
+    if sedit.exit_confirm == Some(crate::tui::app::ExitConfirm::Pending) {
+        let prompt = Line::from(vec![
+            Span::styled(
+                "  Save changes? ",
+                Style::default()
+                    .fg(theme::WARN)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("[y] save  [n] discard  ", theme::dim_style()),
+            Span::styled("(any other key to cancel)", theme::dim_style()),
+        ]);
+        f.render_widget(Paragraph::new(prompt), rows[7]);
+    } else if sedit.dirty {
+        let dirty = Line::from(vec![
+            Span::styled("  ●", Style::default().fg(theme::WARN)),
+            Span::styled(" unsaved changes", theme::dim_style()),
+        ]);
+        f.render_widget(Paragraph::new(dirty), rows[7]);
+    }
+}
+
+fn render_text_field(f: &mut Frame, area: Rect, label: &str, field: &TextField, focused: bool) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+    let label_style = if focused {
+        Style::default()
+            .fg(theme::BADGE_EDIT_BG)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        theme::dim_style()
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!("  {}", label),
+            label_style,
+        ))),
+        rows[0],
+    );
+    let mut spans: Vec<Span<'static>> = vec![Span::styled("  [ ", theme::dim_style())];
+    if focused {
+        let cursor = field.cursor.min(field.value.len());
+        spans.push(Span::raw(field.value[..cursor].to_string()));
+        spans.push(Span::styled("█", Style::default().fg(theme::BADGE_EDIT_BG)));
+        spans.push(Span::raw(field.value[cursor..].to_string()));
+    } else {
+        spans.push(Span::raw(field.value.clone()));
+    }
+    spans.push(Span::styled(" ]", theme::dim_style()));
+    f.render_widget(Paragraph::new(Line::from(spans)), rows[1]);
+}
+
+fn render_category_field(f: &mut Frame, area: Rect, sedit: &SnippetEditState) {
+    let focused = sedit.focused_field == SnippetEditField::Category;
+    let label_style = if focused {
+        Style::default()
+            .fg(theme::BADGE_EDIT_BG)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        theme::dim_style()
+    };
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled("  Category", label_style))),
+        rows[0],
+    );
+    let arrow_style = if focused {
+        Style::default().fg(theme::BADGE_EDIT_BG)
+    } else {
+        theme::dim_style()
+    };
+    let line = Line::from(vec![
+        Span::raw("  "),
+        Span::styled("◂ ", arrow_style),
+        Span::raw(format!("{:?}", sedit.category)),
+        Span::styled(" ▸", arrow_style),
+    ]);
+    f.render_widget(Paragraph::new(line), rows[1]);
+}
+
+fn render_args_field(f: &mut Frame, area: Rect, sedit: &SnippetEditState) {
+    if sedit.args.is_empty() {
+        let placeholder = Line::from(vec![
+            Span::raw("    "),
+            Span::styled("(no args — press 'a' to add)", theme::dim_style()),
+        ]);
+        f.render_widget(Paragraph::new(placeholder), area);
+        return;
+    }
+    let focus_active = sedit.focused_field == SnippetEditField::Args;
+    let edit_style = Style::default().fg(theme::BADGE_EDIT_BG);
+    let items: Vec<ListItem> = sedit
+        .args
+        .iter()
+        .enumerate()
+        .map(|(i, arg)| {
+            let is_selected = focus_active && i == sedit.args_selected;
+            let indicator = if is_selected { "▸ " } else { "  " };
+            let mut line_spans: Vec<Span<'static>> = vec![
+                Span::raw("  "),
+                Span::styled(indicator, edit_style),
+                Span::styled(format!("[{}] ", i), theme::dim_style()),
+            ];
+            if let Some(token) = sedit.token_edit.as_ref().filter(|_| is_selected) {
+                let cursor = token.cursor.min(token.value.len());
+                line_spans.push(Span::raw(token.value[..cursor].to_string()));
+                line_spans.push(Span::styled("█", edit_style));
+                line_spans.push(Span::raw(token.value[cursor..].to_string()));
+            } else {
+                line_spans.push(Span::raw(arg.clone()));
+            }
+            ListItem::new(Line::from(line_spans))
+        })
+        .collect();
+    let list = List::new(items);
+    f.render_widget(list, area);
+}

--- a/src/tui/render/library_pane.rs
+++ b/src/tui/render/library_pane.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::tui::app::{
     App, DrawerRow, LibraryState, SnippetEditField, SnippetEditMode, SnippetEditState,
-    SnippetsDrawerState, TextField, is_builtin_snippet_name,
+    SnippetsDrawerState, TextField,
 };
 use crate::tui::theme;
 
@@ -67,7 +67,7 @@ fn render_left_tree(f: &mut Frame, area: Rect, lib: &LibraryState) {
         render_filter_input(f, layout[1], &lib.snippets.filter.query);
         let sep: String = "─".repeat(layout[2].width as usize);
         f.render_widget(Paragraph::new(sep).style(theme::dim_style()), layout[2]);
-        render_drawer_list(f, layout[3], &lib.snippets, focused);
+        render_drawer_list(f, layout[3], &lib.snippets, &lib.user_only, focused);
     } else {
         let layout = Layout::default()
             .direction(Direction::Vertical)
@@ -77,7 +77,7 @@ fn render_left_tree(f: &mut Frame, area: Rect, lib: &LibraryState) {
                 Constraint::Length(1),
             ])
             .split(inner);
-        render_drawer_list(f, layout[1], &lib.snippets, focused);
+        render_drawer_list(f, layout[1], &lib.snippets, &lib.user_only, focused);
     }
 }
 
@@ -90,7 +90,13 @@ fn render_filter_input(f: &mut Frame, area: Rect, query: &TextField) {
     f.render_widget(Paragraph::new(line), area);
 }
 
-fn render_drawer_list(f: &mut Frame, area: Rect, drawer: &SnippetsDrawerState, focused: bool) {
+fn render_drawer_list(
+    f: &mut Frame,
+    area: Rect,
+    drawer: &SnippetsDrawerState,
+    user_only: &[crate::snippets::Snippet],
+    focused: bool,
+) {
     let rows = drawer.visible_rows();
     if rows.is_empty() {
         let msg = if drawer.snippets.is_empty() {
@@ -137,10 +143,11 @@ fn render_drawer_list(f: &mut Frame, area: Rect, drawer: &SnippetsDrawerState, f
                 DrawerRow::Snippet { snippet_index } => {
                     let snippet = &drawer.snippets[*snippet_index];
                     let indicator = if is_selected { "▸ " } else { "  " };
-                    let badge = if is_builtin_snippet_name(&snippet.name) {
-                        Span::styled(" [builtin]", theme::dim_style())
-                    } else {
+                    let is_user_owned = user_only.iter().any(|u| u.name == snippet.name);
+                    let badge = if is_user_owned {
                         Span::styled(" [user]", Style::default().fg(theme::BADGE_LIBRARY_BG))
+                    } else {
+                        Span::styled(" [builtin]", theme::dim_style())
                     };
                     ListItem::new(Line::from(vec![
                         Span::styled("    ", theme::dim_style()),
@@ -197,7 +204,7 @@ fn render_right_detail(f: &mut Frame, area: Rect, lib: &LibraryState) {
         f.render_widget(p, area);
         return;
     };
-    let is_builtin = is_builtin_snippet_name(&snippet.name);
+    let is_builtin = !lib.user_only.iter().any(|u| u.name == snippet.name);
 
     let mut lines: Vec<Line<'static>> = vec![
         Line::from(""),

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -2,9 +2,11 @@
 //! All public entry is the [`draw`] dispatcher; submodule render fns are
 //! `pub(super)` and not visible outside this module tree.
 
+mod edit_pane;
 mod empty;
 mod help;
 mod left_pane;
+mod library_pane;
 mod right_pane;
 mod status_bar;
 mod top_bar;
@@ -34,7 +36,12 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
 
     top_bar::render(f, chunks[0], app);
 
-    if app.is_empty() {
+    if app.library.is_some() {
+        library_pane::render(f, chunks[1], app);
+    } else if app.edit.is_some() {
+        // Edit mode owns the full middle area.
+        edit_pane::render(f, chunks[1], app);
+    } else if app.is_empty() {
         empty::render_middle(f, chunks[1], app);
     } else if app.visible_indices().is_empty() {
         // Filter is active but no entry matches. Keep the left pane (so the

--- a/src/tui/render/status_bar.rs
+++ b/src/tui/render/status_bar.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::Paragraph,
 };
 
-use crate::tui::app::{App, BrowseSubMode, MessageKind};
+use crate::tui::app::{App, BrowseSubMode, EditFocus, MessageKind, SnippetEditField};
 use crate::tui::theme;
 
 pub(super) fn render(f: &mut Frame, area: Rect, app: &App) {
@@ -25,6 +25,78 @@ pub(super) fn render(f: &mut Frame, area: Rect, app: &App) {
 
     if app.show_help {
         let line = bracket_hints(&[("any key", "dismiss help")]);
+        f.render_widget(Paragraph::new(line).alignment(Alignment::Left), area);
+        return;
+    }
+
+    if let Some(lib) = &app.library {
+        // SnippetEdit nested sub-mode.
+        if let Some(sedit) = &lib.edit {
+            let hints: &[(&str, &str)] = if sedit.token_edit.is_some() {
+                &[
+                    ("Enter/Esc", "done"),
+                    ("←→", "cursor"),
+                    ("Backspace", "del"),
+                ]
+            } else if sedit.focused_field == SnippetEditField::Args {
+                &[
+                    ("↑↓", "nav"),
+                    ("Enter", "edit token"),
+                    ("a", "add"),
+                    ("J/K", "reorder"),
+                    ("d", "del"),
+                    ("Ctrl+S", "save"),
+                    ("Esc", "cancel"),
+                ]
+            } else {
+                &[
+                    ("↑↓", "field"),
+                    ("←→", "cursor / category"),
+                    ("Ctrl+S", "save"),
+                    ("Esc", "cancel"),
+                ]
+            };
+            let line = bracket_hints(hints);
+            f.render_widget(Paragraph::new(line).alignment(Alignment::Left), area);
+            return;
+        }
+        if lib.delete_confirm.is_some() {
+            let line = bracket_hints(&[("y", "delete"), ("n", "cancel"), ("any other", "cancel")]);
+            f.render_widget(Paragraph::new(line).alignment(Alignment::Left), area);
+            return;
+        }
+        let line = bracket_hints(&[
+            ("Ctrl+L", "exit"),
+            ("↑↓", "nav"),
+            ("Space", "fold"),
+            ("/", "filter"),
+            ("n", "new"),
+            ("e", "edit"),
+            ("d", "delete"),
+            ("?", "help"),
+        ]);
+        f.render_widget(Paragraph::new(line).alignment(Alignment::Left), area);
+        return;
+    }
+
+    if let Some(edit) = &app.edit {
+        let hints: &[(&str, &str)] = match edit.focus {
+            EditFocus::Editor => &[
+                ("Tab", "snippets"),
+                ("↑↓", "field"),
+                ("Ctrl+S", "save"),
+                ("Esc", "cancel"),
+            ],
+            EditFocus::SnippetsDrawer => &[
+                ("Tab", "editor"),
+                ("↑↓", "nav"),
+                ("Space", "fold"),
+                ("/", "filter"),
+                ("→", "insert"),
+                ("Esc", "cancel"),
+            ],
+        };
+        let line = bracket_hints(hints);
         f.render_widget(Paragraph::new(line).alignment(Alignment::Left), area);
         return;
     }

--- a/src/tui/render/top_bar.rs
+++ b/src/tui/render/top_bar.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Paragraph},
 };
 
-use crate::tui::app::{App, BrowseSubMode, is_builtin_snippet_name};
+use crate::tui::app::{App, BrowseSubMode};
 use crate::tui::scan::ConfigEntry;
 use crate::tui::theme;
 
@@ -78,13 +78,13 @@ fn stats_spans(app: &App) -> Vec<Span<'static>> {
         }
 
         let total = lib.snippets.snippets.len();
-        let builtin = lib
+        let user = lib
             .snippets
             .snippets
             .iter()
-            .filter(|s| is_builtin_snippet_name(&s.name))
+            .filter(|s| lib.user_only.iter().any(|u| u.name == s.name))
             .count();
-        let user = total - builtin;
+        let builtin = total - user;
         return vec![
             Span::styled(total.to_string(), bold),
             Span::raw(" "),

--- a/src/tui/render/top_bar.rs
+++ b/src/tui/render/top_bar.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Paragraph},
 };
 
-use crate::tui::app::{App, BrowseSubMode};
+use crate::tui::app::{App, BrowseSubMode, is_builtin_snippet_name};
 use crate::tui::scan::ConfigEntry;
 use crate::tui::theme;
 
@@ -18,8 +18,17 @@ pub(super) fn render(f: &mut Frame, area: Rect, app: &App) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    // Compose left half (brand + stats) and right half (mode badge).
-    let badge_text = " BROWSE ";
+    let (badge_text, badge_style) = if let Some(lib) = &app.library {
+        if lib.edit.is_some() {
+            (" EDIT ", theme::badge_edit())
+        } else {
+            (" LIBRARY ", theme::badge_library())
+        }
+    } else if app.edit.is_some() {
+        (" EDIT ", theme::badge_edit())
+    } else {
+        (" BROWSE ", theme::badge_browse())
+    };
     let badge_width = badge_text.chars().count() as u16;
     let cols = Layout::default()
         .direction(Direction::Horizontal)
@@ -43,12 +52,53 @@ pub(super) fn render(f: &mut Frame, area: Rect, app: &App) {
     let para = Paragraph::new(Line::from(spans)).alignment(Alignment::Left);
     f.render_widget(para, cols[0]);
 
-    let badge = Paragraph::new(badge_text).style(theme::badge_browse());
+    let badge = Paragraph::new(badge_text).style(badge_style);
     f.render_widget(badge, cols[1]);
 }
 
 /// Build the inline "stats" run of spans shown after the brand.
 fn stats_spans(app: &App) -> Vec<Span<'static>> {
+    // Library mode replaces the entries stats with snippets stats.
+    if let Some(lib) = &app.library {
+        let bold = Style::default().add_modifier(Modifier::BOLD);
+        let dim = theme::dim_style();
+        let lib_color = Style::default()
+            .fg(theme::BADGE_LIBRARY_BG)
+            .add_modifier(Modifier::BOLD);
+
+        // Editing sub-mode → focused title.
+        if let Some(sedit) = &lib.edit {
+            let title = match &sedit.mode {
+                crate::tui::app::SnippetEditMode::Create => "Editing new snippet".to_string(),
+                crate::tui::app::SnippetEditMode::Update { original_name } => {
+                    format!("Editing snippet '{}'", original_name)
+                }
+            };
+            return vec![Span::styled(title, dim)];
+        }
+
+        let total = lib.snippets.snippets.len();
+        let builtin = lib
+            .snippets
+            .snippets
+            .iter()
+            .filter(|s| is_builtin_snippet_name(&s.name))
+            .count();
+        let user = total - builtin;
+        return vec![
+            Span::styled(total.to_string(), bold),
+            Span::raw(" "),
+            Span::styled("snippets", dim),
+            Span::styled("  ·  ", dim),
+            Span::styled(builtin.to_string(), bold),
+            Span::raw(" "),
+            Span::styled("builtin", dim),
+            Span::styled("  ·  ", dim),
+            Span::styled(user.to_string(), lib_color),
+            Span::raw(" "),
+            Span::styled("user", dim),
+        ];
+    }
     let total = app.entries.len();
     let ok = app
         .entries


### PR DESCRIPTION
Second milestone of Phase 4. The TUI evolves from a launcher into
a full configuration editor, with a curated library of 42 QEMU
argument snippets to make common setups trivial.

## Changes

### Added
- **Snippet library system**: 42 curated builtin QEMU argument
  snippets across 8 categories (Memory, CPU, Machine, Storage,
  Network, Display, Debug, Kernel) plus a `~/.vex/snippets.json`
  user library for custom entries. User snippets merge with builtins,
  with user entries overriding by name.
- **TUI Edit mode**: press `e` on a configuration to edit it
  in-place, or `n` to create a new one. Fields: name, QEMU binary,
  description, and args (with reorder, delete, add, and in-place
  token editing). Resources remain CLI-managed.
- **TUI Snippets drawer** (Edit mode right pane): merged snippets
  grouped by category with fold/unfold, filter, and `→` to insert
  into the current args position.
- **TUI Library mode** (`Ctrl+L`): full-screen snippet manager.
  Browse with details panel; `n` / `e` / `d` to create, edit, or
  delete user snippets. Persists to `~/.vex/snippets.json` via
  atomic write (temp-file + rename). Builtin snippets are read-only.
- **Args token editing**: in Edit mode and Library snippet edit,
  press `Enter` on an arg to edit its string in place, or `a` to add
  an empty arg and immediately start editing it.

### Changed
- **Edit mode `Tab` semantics**: `Tab` switches between the Editor
  and Snippets panes; field cycling within the Editor uses `↑` / `↓`.

### Notes
- Snippets file uses `schema_version: 1`. Forward-compatible
  deserialization is planned for a later release.
- Carry-over from 0.4.0 development: help overlay is panic-safe on
  tiny terminals, right-pane scroll clamps and writes back,
  `Ctrl+C` always quits regardless of mode/overlay.

## Verification

- `cargo build` / `cargo test` (495 passed, 1 ignored) /
  `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` /
  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — all clean
- Implementation split across two commits:
  - `feat(snippets): data layer with 42 builtin entries and user library merge`
  - `feat(tui): Edit mode, Snippets drawer, and Library mode (0.4.1)`

## Pending (not blocking)

- Screenshots for the new Edit mode and Library mode will be added
  to README after a manual TTY pass. README has placeholders.
- 0.4.2 backlog: Schema v3 with category field, tree grouping view,
  Hub async fetching.