### PR TITLE
fix: sort vex list output by configuration name

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -44,6 +44,8 @@ pub fn list_command() -> VexResult<()> {
         }
     }
 
+    configs.sort_by(|a, b| a.0.cmp(&b.0));
+
     if configs.is_empty() {
         println!("No configurations found.");
     } else {

--- a/src/tests/test_list.rs
+++ b/src/tests/test_list.rs
@@ -102,6 +102,42 @@ fn test_list_multiple_configs() {
 }
 
 #[test]
+fn test_list_sorts_configs_by_name() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".vex");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    let vex_bin = CargoBuild::new()
+        .bin("vex")
+        .current_release()
+        .run()
+        .unwrap();
+
+    for name in ["zeta", "Alpha", "beta"] {
+        vex_bin
+            .command()
+            .env("VEX_CONFIG_DIR", &config_dir)
+            .args(["save", name, "qemu-system-x86_64"])
+            .output()
+            .unwrap();
+    }
+
+    let output = vex_bin
+        .command()
+        .env("VEX_CONFIG_DIR", &config_dir)
+        .arg("list")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let alpha = stdout.find("  Alpha -").unwrap();
+    let beta = stdout.find("  beta -").unwrap();
+    let zeta = stdout.find("  zeta -").unwrap();
+    assert!(alpha < beta && beta < zeta, "{stdout}");
+}
+
+#[test]
 fn test_list_shows_descriptions() {
     let temp_dir = TempDir::new().unwrap();
     let config_dir = temp_dir.path().join(".vex");


### PR DESCRIPTION
## Summary

- sort saved configurations by name before rendering `vex list`
- add a regression test covering deterministic ascending, case-sensitive output

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test test_list_sorts_configs_by_name` (1 passed)
- `cargo test --all-targets` on this branch: 515 passed, 8 failed, 1 ignored
- clean `upstream/main` baseline: 514 passed, the same 8 failed, 1 ignored

The eight full-suite failures are existing Windows portability assumptions: seven CLI exec tests expect Unix executable behavior, and one integration test launches `/bin/echo` (Windows `os error 3`). The added sorting test passes in the full run.

Closes #33.