### PR TITLE
fix: include all subcommands in Zsh completions

### DIFF
--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -188,8 +188,12 @@ _vex() {{
                 "pull:Pull a shared configuration from the remote registry"
                 "push:Push a local configuration to the remote registry"
                 "exec:Execute a saved QEMU configuration"
-                "edit:Edit a saved QEMU configuration"
                 "completions:Generate shell completion scripts"
+                "edit:Edit a saved QEMU configuration"
+                "resource:Manage resources bound to a configuration"
+                "cache:Manage the resource cache"
+                "hub:Browse and install entries from the Vex Hub"
+                "tui:Launch the interactive TUI"
             )
             _describe -t commands 'vex command' cmds
             ;;

--- a/src/tests/test_completions.rs
+++ b/src/tests/test_completions.rs
@@ -1,4 +1,7 @@
+use clap::CommandFactory;
 use escargot::CargoBuild;
+
+use crate::commands::Cli;
 
 fn vex_bin() -> escargot::CargoRun {
     CargoBuild::new()
@@ -30,6 +33,36 @@ fn completions_zsh() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("vex") || stdout.contains("_vex"));
+}
+
+#[test]
+fn zsh_dynamic_completion_lists_all_cli_subcommands() {
+    let output = vex_bin()
+        .command()
+        .args(["completions", "zsh"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let command_block = stdout
+        .split("cmds=(")
+        .nth(1)
+        .and_then(|rest| rest.split_once("\n            )\n"))
+        .map(|(block, _)| block)
+        .expect("Zsh dynamic completion command block");
+    let actual: Vec<_> = command_block
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix('"'))
+        .filter_map(|line| line.split(':').next())
+        .map(str::to_owned)
+        .collect();
+    let expected: Vec<_> = Cli::command()
+        .get_subcommands()
+        .map(|command| command.get_name().to_owned())
+        .collect();
+
+    assert_eq!(actual, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- I added the missing `resource`, `cache`, `hub`, and `tui` entries to the custom Zsh completion command list.
- I added a regression test that compares the custom list with Clap's current top-level subcommands, so future command additions cannot silently drift.
- I preserved the existing dynamic configuration-name and cache-hash completion helpers.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (526 passed, 1 ignored)
- `git diff --check`

Fixes #35
